### PR TITLE
fix: correct model download size label from ~5 GB to ~21 GB

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -885,7 +885,7 @@
       p('  printf "%s✓%s Ollama already installed\\n" "$_c_green" "$_c_reset"');
       p('fi');
       p('');
-      p('step "Journalism model download (~5 GB)"');
+      p('step "Journalism model download (~21 GB)"');
       p('echo "Ollama will stream download progress below — grab a coffee, 5–15 min on a typical connection."');
       p('echo ""');
       p('ollama pull ' + shellEscape('hf.co/' + cfg.model_repo) + ' || {');


### PR DESCRIPTION
## Summary
- The generated installer script step banner read "~5 GB" while the setup form UI correctly showed "~21 GB" for the Qwen3.6-35B-A3B model
- One-line fix in `setup.html` line 888 to match the UI label

Closes #11

## Test plan
- [ ] Generate a local-mode installer from `setup.html` and confirm the step banner reads "Journalism model download (~21 GB)"
- [ ] Verify UI labels in the local-section card still say "~21 GB" (lines 361, 382 — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)