### PR TITLE
fix: use --prefix to avoid EACCES on npm global install of pi

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -894,7 +894,9 @@
       p('}');
       p('');
       p('if ! command -v pi >/dev/null 2>&1; then');
-      p('  spin "Installing pi (@mariozechner/pi-coding-agent)" npm install -g @mariozechner/pi-coding-agent');
+      p('  NPM_PREFIX="$HOME/.npm-global"; mkdir -p "$NPM_PREFIX"');
+      p('  spin "Installing pi (@mariozechner/pi-coding-agent)" npm install -g --prefix "$NPM_PREFIX" @mariozechner/pi-coding-agent');
+      p('  export PATH="$NPM_PREFIX/bin:$PATH"');
       p('else');
       p('  printf "%s✓%s pi already installed\\n" "$_c_green" "$_c_reset"');
       p('fi');
@@ -1015,6 +1017,7 @@
     p('  cat >> "$SHELL_RC" <<\'SHELL_EOF\'');
     p('');
     p('# SPOTLIGHT-BEGIN — added by setup.html installer');
+    p('export PATH="$HOME/.npm-global/bin:$PATH"');
     p('spotlight() {');
     p('  local dir="${SPOTLIGHT_DIR:-$HOME/spotlight}"');
     p('  if [ ! -d "$dir" ]; then');


### PR DESCRIPTION
## Summary
- `npm install -g @mariozechner/pi-coding-agent` fails on macOS where `/usr/local/lib/node_modules` is not user-writable (the default)
- Install pi into `$HOME/.npm-global` via `--prefix`, then export its `bin/` to PATH at install time
- Also add `$HOME/.npm-global/bin` to the `SPOTLIGHT-BEGIN` shell rc block so `pi` is available in future sessions

Closes #10

## Test plan
- [ ] Run a generated local-mode installer on a stock macOS system (no sudo npm) — `pi` installs cleanly with no EACCES error
- [ ] Open a new terminal after install — `which pi` resolves to `~/.npm-global/bin/pi`
- [ ] Run `spotlight` — `pi` is on PATH and launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)