### PR TITLE
fix: make preflight self-contained by auto-loading .env

### DIFF
--- a/monitoring/feeds/_preflight_base.py
+++ b/monitoring/feeds/_preflight_base.py
@@ -19,6 +19,28 @@ from pathlib import Path
 from typing import Callable
 
 
+def _load_dotenv(root: Path) -> None:
+    """Load repo-root .env into os.environ without requiring python-dotenv.
+
+    Uses a minimal parser that handles KEY=VALUE and KEY='VALUE' lines,
+    skipping comments and blanks. Existing env vars are NOT overwritten
+    (same semantics as `set -a; source .env; set +a` with pre-existing exports).
+    """
+    env_path = root / ".env"
+    if not env_path.is_file():
+        return
+    with open(env_path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            key = key.strip()
+            val = val.strip().strip("'\"")
+            if key and key not in os.environ:
+                os.environ[key] = val
+
+
 def discover_manifests(root: Path) -> list[dict]:
     """Scan `root` for subdirectories containing manifest.json. Returns
     each parsed manifest with an injected `_dir` field pointing at the
@@ -130,6 +152,16 @@ def run_preflight(
     description: str = "Spotlight preflight",
 ) -> None:
     """Full preflight entry point — argparse, discovery, reports, exit."""
+    # Auto-load .env from repo root so preflight is self-contained regardless
+    # of whether the caller sourced .env in the shell beforehand.
+    # Walk up from `root` until we find a .env file or exhaust the tree.
+    _dotenv_dir = root.resolve()
+    while _dotenv_dir != _dotenv_dir.parent:
+        if (_dotenv_dir / ".env").is_file():
+            break
+        _dotenv_dir = _dotenv_dir.parent
+    _load_dotenv(_dotenv_dir)
+
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--smoke-test", action="store_true",
                         help="Also run a minimal probe against each entry")


### PR DESCRIPTION
## Summary
- `_preflight_base.check_env_vars()` reads from `os.environ` only — when either preflight script is run without `.env` already sourced in the shell, every key-requiring integration reports red despite the key being present in `.env`
- Affects `spotlight update`, standalone `python3 integrations/preflight.py` calls, and any CI context
- Added a zero-dependency `_load_dotenv()` helper in `_preflight_base.py` that walks up from the scan root to find the repo `.env` and loads it into `os.environ`, without overwriting vars already set in the environment
- Applied in `run_preflight()` so both `integrations/preflight.py` and `monitoring/feeds/preflight.py` benefit automatically — no changes needed to caller scripts

Closes #12

## Unexpected finding
The `setup.html` installer's preflight step (line 1065) already does `set -a; source "$SPOTLIGHT_DIR/.env"; set +a` which exports vars to the `python3` subprocess — so the installer run itself was likely fine. The failure reproduces when calling `spotlight update` or running either preflight script directly, since those paths don't source `.env` first.

## Test plan
- [ ] Write a key to `~/spotlight/.env`, then run `python3 ~/spotlight/integrations/preflight.py --text` in a fresh shell (without sourcing `.env`) — integration shows green
- [ ] Run `python3 ~/spotlight/monitoring/feeds/preflight.py --text` in a fresh shell — sources go green where keys are set
- [ ] Existing env vars are not overwritten (set `OSINT_NAV_API_KEY=override` in shell before running — preflight uses the shell value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)