### PR TITLE
fix: handle diverged repo in installer update step

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -861,7 +861,7 @@
     p('');
     p('step "Spotlight repo"');
     p('if [ -d "$SPOTLIGHT_DIR/.git" ]; then');
-    p('  spin "Updating Spotlight at $SPOTLIGHT_DIR" git -C "$SPOTLIGHT_DIR" pull --ff-only');
+    p('  spin "Updating Spotlight at $SPOTLIGHT_DIR" bash -c \'git -C "$SPOTLIGHT_DIR" fetch origin && git -C "$SPOTLIGHT_DIR" reset --hard origin/main\'');
     p('else');
     p('  spin "Cloning Spotlight to $SPOTLIGHT_DIR" git clone "$REPO_URL" "$SPOTLIGHT_DIR"');
     p('fi');


### PR DESCRIPTION
## Summary

- Replaces `git pull --ff-only` with `git fetch origin && git reset --hard origin/main` in the installer's Spotlight repo update branch
- `--ff-only` fails with a non-zero exit when the local repo has diverged, which under `set -euo pipefail` kills the entire installer
- The new approach works regardless of local state and is idempotent

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)