### PR TITLE
fix: use $HOME/.npm-global prefix for gemini-cli install to avoid EACCES

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -928,7 +928,13 @@
         : 'Runtime: ' + r.name;
       p('step "' + label + '"');
       p('if ! command -v ' + r.bin + ' >/dev/null 2>&1; then');
-      p('  spin "Installing ' + r.installPkg + '" npm install -g ' + r.installPkg);
+      if (cfg.runtime === 'gemini') {
+        p('  NPM_PREFIX="$HOME/.npm-global"; mkdir -p "$NPM_PREFIX"');
+        p('  spin "Installing ' + r.installPkg + '" npm install -g --prefix "$NPM_PREFIX" ' + r.installPkg);
+        p('  export PATH="$NPM_PREFIX/bin:$PATH"');
+      } else {
+        p('  spin "Installing ' + r.installPkg + '" npm install -g ' + r.installPkg);
+      }
       p('else');
       p('  printf "%s✓%s ' + r.bin + ' already installed\\n" "$_c_green" "$_c_reset"');
       p('fi');


### PR DESCRIPTION
Closes #18

## Summary
- Special-cases the Gemini runtime install block to use `$HOME/.npm-global` prefix, same pattern as the pi fix (#14)
- Avoids EACCES on macOS systems where `/usr/local/lib/node_modules` is not user-writable
- PATH export ensures gemini is available immediately in the same session

## Test plan
- [ ] Run installer in cloud/gemini mode on a system with system node (macOS default)
- [ ] Verify `gemini` command is available after install without sudo
- [ ] Verify other cloud runtimes (claude, codex, opencode) install path is unchanged