### PR TITLE
fix: replace git pull --ff-only with fetch+reset in spotlight update subcommand

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1027,7 +1027,7 @@
     p('  # Subcommands');
     p('  case "${1:-}" in');
     p('    update)');
-    p('      (cd "$dir" && git pull --ff-only && \\');
+    p('      (cd "$dir" && git fetch origin && git reset --hard origin/main && \\');
     p('        python3 monitoring/feeds/preflight.py --text && \\');
     p('        python3 integrations/preflight.py --text)');
     p('      return $?');


### PR DESCRIPTION
Closes #19

## Summary
- The `spotlight update` shell function written to the user's rc file still used `git pull --ff-only`, which crashes when the local repo has diverged
- Replaces it with `git fetch origin && git reset --hard origin/main`, consistent with the installer's own repo step fixed in PR #17

## Test plan
- [ ] Run `spotlight update` on a repo with a diverged local branch
- [ ] Verify it succeeds instead of failing with "Not possible to fast-forward"
- [ ] Verify preflight scripts still run after the reset