### PR TITLE
docs(navigator): bump tool count 1,000+ → 10,000+ + Navigator hyperlinks

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -19,7 +19,7 @@ An agent invokes a **skill** to get *guidance* and calls an **integration** to g
 |---|---|---|---|---|
 | `browser-use` | library | browser-automation | No (optional cloud) | Agent-driven browser automation — form navigation, JS-rendered extraction, multi-step flows. MIT open source. |
 | `junkipedia` | api | social-osint | `JUNKIPEDIA_API_KEY` | Narrative / misinformation tracking across social platforms. Application-based access. |
-| `osint-navigator` | api | tool-discovery | `OSINT_NAV_API_KEY` | 1,000+ OSINT tools with AI-powered synthesized answers. Complements the curated 150-tool catalog in the `osint` skill. |
+| `osint-navigator` | api | tool-discovery | `OSINT_NAV_API_KEY` | 10,000+ OSINT tools with AI-powered synthesized answers. Complements the curated 150-tool catalog in the `osint` skill. |
 | `cojournalist` | api | monitoring | `COJOURNALIST_API_KEY` | Durable monitoring via existing coJournalist projects, scouts, and information units. |
 | `unpaywall` | api | academic-open-access | `UNPAYWALL_EMAIL` | Legal open-access lookup for academic papers by DOI. Used only when selected in setup and green in preflight. |
 

--- a/index.html
+++ b/index.html
@@ -1476,7 +1476,7 @@
           <div class="step-label">Lead</div>
         </div>
         <h3 class="step-title">Start with a lead. Spotlight proposes the methodology before the research starts.</h3>
-        <p class="step-body">You approve the plan first. It can connect to OSINT Navigator and pull the best tooling for the job before the first cycle runs.</p>
+        <p class="step-body">You approve the plan first. It can connect to <a href="https://navigator.indicator.media/" target="_blank" rel="noreferrer">OSINT Navigator</a> and pull the best tooling for the job before the first cycle runs.</p>
       </article>
       <article class="step" data-label="Cycles" data-num="02">
         <div class="step-meta">

--- a/integrations/osint-navigator/integration.md
+++ b/integrations/osint-navigator/integration.md
@@ -1,6 +1,6 @@
 # OSINT Navigator — Tool Discovery API
 
-**What:** A live tool-discovery API maintained by Indicator Media. Weekly-updated database of 1,000+ OSINT tools with AI-powered synthesized answers to investigation-method questions. Complements the curated 150-tool catalog in the `osint` skill's `references/tools-by-category.md`.
+**What:** A live tool-discovery API maintained by Indicator Media. Weekly-updated database of 10,000+ OSINT tools with AI-powered synthesized answers to investigation-method questions. Complements the curated 150-tool catalog in the `osint` skill's `references/tools-by-category.md`.
 
 **When to use:**
 

--- a/integrations/osint-navigator/manifest.json
+++ b/integrations/osint-navigator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "osint-navigator",
   "name": "OSINT Navigator",
-  "description": "Weekly-updated database of 1,000+ OSINT tools with AI-powered query. Surfaces country-specific registries, niche categories, and recent additions beyond the curated 150-tool catalog in the osint skill.",
+  "description": "Weekly-updated database of 10,000+ OSINT tools with AI-powered query. Surfaces country-specific registries, niche categories, and recent additions beyond the curated 150-tool catalog in the osint skill.",
   "category": "tool-discovery",
   "type": "api",
   "requires_key": true,

--- a/setup.html
+++ b/setup.html
@@ -1226,9 +1226,9 @@
       </div>
       <section class="card">
         <p class="lede">
-          A live database of 1,000+ OSINT tools with AI-powered lookup — essential for country-specific registries and niche techniques.
+          A live database of 10,000+ OSINT tools with AI-powered lookup — essential for country-specific registries and niche techniques.
         </p>
-        <label class="block">OSINT Navigator API key <span class="hint">— <a href="https://navigator.indicator.media/" target="_blank">request access</a></span></label>
+        <label class="block">OSINT Navigator API key <span class="hint">— <a href="https://navigator.indicator.media/" target="_blank">Get API key</a></span></label>
         <input type="password" id="nav_key" placeholder="on_..." autocomplete="off">
         <p id="nav_err" class="error hidden">OSINT Navigator key is required.</p>
       </section>

--- a/skills/osint/SKILL.md
+++ b/skills/osint/SKILL.md
@@ -58,7 +58,7 @@ When responding to an investigation query:
 
 ## OSINT Navigator
 
-OSINT Navigator (navigator.indicator.media) is a live tool-discovery API with a weekly-updated database of 1,000+ OSINT tools. **When available, consult Navigator first before using the curated list below.**
+OSINT Navigator (navigator.indicator.media) is a live tool-discovery API with a weekly-updated database of 10,000+ OSINT tools. **When available, consult Navigator first before using the curated list below.**
 
 ### Quick API Access
 


### PR DESCRIPTION
## Summary
- Bumps OSINT Navigator's tool count from 1,000+ → 10,000+ across homepage scrolly, setup form, integration docs, manifest, and the `osint` skill
- Hyperlinks "OSINT Navigator" in scrolly step 01 to https://navigator.indicator.media/
- Setup form CTA: "request access" → "Get API key"

## Test plan
- [ ] Visit homepage — scrolly step 01 link opens Navigator in new tab
- [ ] Visit setup page — section 04 reads "10,000+" with "Get API key" link
- [ ] Skill files (`docs/integrations.md`, `skills/osint/SKILL.md`, `integrations/osint-navigator/*`) all read 10,000+