### PR TITLE
[codex] Add Phantom Tide plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Skills are markdown playbooks loaded via `invoke-skill(skill_id)`. Each skill li
 |----------|------|-------------|--------------|
 | `spotlight` | `skills/spotlight/SKILL.md` | Investigation orchestrator — pipeline phases, gates, cycle evaluation | orchestrator (top-level) |
 | `review` | `skills/review/SKILL.md` | Post-Gate-1 HTML review artifact + structured feedback loop; re-spawns investigator on feedback submission | orchestrator, user |
-| `integrations` | `skills/integrations/SKILL.md` | Routing layer for external tool integrations — browser-use, Junkipedia, OSINT Navigator, Unpaywall. Reads live preflight status, maps investigation tasks to integrations | investigator, fact-checker, orchestrator |
+| `integrations` | `skills/integrations/SKILL.md` | Routing layer for external tool integrations — browser-use, Junkipedia, OSINT Navigator, Phantom Tide, Unpaywall. Reads live preflight status, maps investigation tasks to integrations | investigator, fact-checker, orchestrator |
 | `ingest` | `skills/ingest/SKILL.md` | Knowledge archival — vault ingestion from case files | orchestrator, user |
 | `monitoring` | `skills/monitoring/SKILL.md` | Monitoring orchestration — Mycroft passive signals, coJournalist projects/scouts, runtime-native fallbacks | orchestrator |
 | `web-archiving` | `skills/web-archiving/SKILL.md` | Wayback Machine, Archive.today, local archival with chain of custody | investigator, fact-checker |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Runtime-agnostic OSINT investigation system for journalists. Verified findings, 
 
 ## Install (for journalists)
 
-**Open [`setup.html`](setup.html) in any browser.** Pick your runtime, paste your Firecrawl and OSINT Navigator API keys, optionally select integrations (browser-use, Junkipedia, Unpaywall), and click Generate. You'll get two install options:
+**Open [`setup.html`](setup.html) in any browser.** Pick your runtime, paste your Firecrawl and OSINT Navigator API keys, optionally select integrations (browser-use, Junkipedia, Unpaywall, Phantom Tide), and click Generate. You'll get two install options:
 
 - **Copy into Terminal** (simplest) — click Copy, ⌘+Space → Terminal → ⌘+V → Return
 - **Download installer** — `spotlight-setup.zip` → extract → double-click the `.command` file (macOS Gatekeeper first-time: right-click → Open → Confirm)
@@ -46,7 +46,7 @@ Per-runtime wiring: **[docs/runtimes.md](docs/runtimes.md)**.
 - **6 readiness criteria**: enforced before Gate 1 — min findings, source independence, no unresolved disputes, affected perspective, document trail, gap assessment
 - **Evidence grounding**: scrape-before-cite, every source has a `local_file`, archive hierarchy Wayback → Archive.today → local
 - **11 skills**: orchestrator (spotlight), review (post-Gate-1 HTML feedback loop), integrations (routing), ingest, monitoring, web-archiving, content-access, osint, investigate, follow-the-money, social-media-intelligence
-- **4 external integrations shipped**: browser-use (AI browser automation), Junkipedia (narrative tracking), OSINT Navigator (tool discovery), Unpaywall (academic open access). Framework accepts more — see [docs/integrations.md](docs/integrations.md).
+- **5 external integrations shipped**: browser-use (AI browser automation), Junkipedia (narrative tracking), OSINT Navigator (tool discovery), Phantom Tide (transport intelligence), Unpaywall (academic open access). Framework accepts more — see [docs/integrations.md](docs/integrations.md).
 - **Monitoring orchestration**: passive signals from Mycroft plus durable monitors from Scoutpost or runtime-native routines
 - **Knowledge vault ingestion**: Markdown vaults for Obsidian or Tolaria, with directory fallback; atomic registry updates; lock-file concurrency
 - **Sensitive mode**: strips `fetch`/`search` from agents; investigation runs local-only
@@ -77,7 +77,7 @@ Optional:
 | **[docs/README.md](docs/README.md)** | Start here — entry point and quick-start per runtime |
 | **[docs/structure.md](docs/structure.md)** | Repo layout, 13-verb registry, how to extend |
 | **[docs/runtimes.md](docs/runtimes.md)** | Per-runtime wiring — pi, Hermes, Goose, Codex, Gemini, local OAI |
-| **[docs/integrations.md](docs/integrations.md)** | External tool integrations (browser-use, Junkipedia, OSINT Navigator, Unpaywall), setup flow, manifest contract |
+| **[docs/integrations.md](docs/integrations.md)** | External tool integrations (browser-use, Junkipedia, OSINT Navigator, Phantom Tide, Unpaywall), setup flow, manifest contract |
 | **[docs/investigating.md](docs/investigating.md)** | Pipeline phases, gates, cycles, readiness, stall protocol |
 | **[docs/fact-checking.md](docs/fact-checking.md)** | Independence, SIFT, verdict taxonomy, evidence trails |
 | **[docs/monitoring.md](docs/monitoring.md)** | Monitoring lifecycle across Mycroft, Scoutpost, and runtime-native fallbacks |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ If you are new to Spotlight, read in this order:
 
 1. **[structure.md](structure.md)** — how this repo is laid out; what each file is for; the 13-verb contract
 2. **[runtimes.md](runtimes.md)** — how to wire Spotlight into pi, Hermes, Goose, Codex, Gemini, or a local OpenAI-compatible fine-tune
-3. **[integrations.md](integrations.md)** — external OSINT tool integrations (browser-use, Junkipedia, OSINT Navigator, Unpaywall), manifest contract, preflight
+3. **[integrations.md](integrations.md)** — external OSINT tool integrations (browser-use, Junkipedia, OSINT Navigator, Phantom Tide, Unpaywall), manifest contract, preflight
 4. **[investigating.md](investigating.md)** — the investigation pipeline: brief, methodology, cycles, gates, readiness, stall protocol
 5. **[fact-checking.md](fact-checking.md)** — the independent verification pass: SIFT, verdict taxonomy, evidence trails
 6. **[monitoring.md](monitoring.md)** — monitoring orchestration across Mycroft, Scoutpost, and runtime-native fallbacks

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -9,7 +9,7 @@ This doc is the operator overview. See `integrations/README.md` for the manifest
 | Concept | Lives at | Example | What it holds |
 |---|---|---|---|
 | **Skill** | `skills/<id>/SKILL.md` | `osint`, `follow-the-money`, `investigate` | Methodology playbook the agent follows. No credentials. |
-| **Integration** | `integrations/<id>/` | `browser-use`, `junkipedia`, `osint-navigator` | Specific external tool with its own API contract + credentials. |
+| **Integration** | `integrations/<id>/` | `browser-use`, `junkipedia`, `osint-navigator`, `phantom-tide` | Specific external tool with its own API contract + credentials. |
 
 An agent invokes a **skill** to get *guidance* and calls an **integration** to get *direct data from a specific vendor or platform*. Passive feed signals now live in Mycroft, not Spotlight.
 
@@ -20,6 +20,7 @@ An agent invokes a **skill** to get *guidance* and calls an **integration** to g
 | `browser-use` | library | browser-automation | No (optional cloud) | Agent-driven browser automation — form navigation, JS-rendered extraction, multi-step flows. MIT open source. |
 | `junkipedia` | api | social-osint | `JUNKIPEDIA_API_KEY` | Narrative / misinformation tracking across social platforms. Application-based access. |
 | `osint-navigator` | api | tool-discovery | `OSINT_NAV_API_KEY` | 10,000+ OSINT tools with AI-powered synthesized answers. Complements the curated 150-tool catalog in the `osint` skill. |
+| `phantom-tide` | api | transport-intelligence | `PHANTOM_TIDE_API_KEY` | Aircraft restricted-airspace crossing candidates and source-freshness context. Maritime/convergence routes are planned pending a stable API contract. |
 | `scoutpost` | api | monitoring | `SCOUTPOST_API_KEY` | Durable monitoring via existing Scoutpost projects, scouts, and information units. |
 | `unpaywall` | api | academic-open-access | `UNPAYWALL_EMAIL` | Legal open-access lookup for academic papers by DOI. Used only when selected in setup and green in preflight. |
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -14,7 +14,7 @@ spotlight/
 ├── schemas/                  # JSON schemas — 5 case files, all schema_version 1.0
 ├── skills/                   # 11 skills (pi-native SKILL.md format)
 ├── agents/                   # 2 agent prompt bundles (investigator + fact-checker)
-├── integrations/             # External tool integrations (browser-use, Junkipedia, OSINT Navigator, Unpaywall)
+├── integrations/             # External tool integrations (browser-use, Junkipedia, OSINT Navigator, Phantom Tide, Unpaywall)
 ├── docs/                     # You are here. Operator manual.
 ├── monitoring/               # Case-level monitor registry helper + leads queue
 └── cases/                    # Per-investigation output (gitignored)
@@ -80,7 +80,7 @@ Each skill is a directory with `SKILL.md` (+ optional `references/*.md` for larg
 ### Pipeline-support skills (invocable by orchestrator)
 
 - **`review`** — post-Gate-1 HTML review artifact. Renders a self-contained `cases/{project}/review.html` the journalist opens in any browser, submits structured feedback, downloads as JSON. Mode B re-spawns the investigator to process the feedback and regenerates the HTML. No server required.
-- **`integrations`** — routing layer for external tool integrations (browser-use, Junkipedia, OSINT Navigator, Unpaywall). Reads live preflight status, maps investigation tasks to integrations. See `integrations/` at repo root for manifests + per-integration usage docs.
+- **`integrations`** — routing layer for external tool integrations (browser-use, Junkipedia, OSINT Navigator, Phantom Tide, Unpaywall). Reads live preflight status, maps investigation tasks to integrations. See `integrations/` at repo root for manifests + per-integration usage docs.
 - **`ingest`** — archival from case files to vault. 7-step process with `.ingest-lock` concurrency and directory fallback.
 - **`monitoring`** — case-level monitoring orchestration. Coordinates Mycroft passive signals, Scoutpost durable monitors, and runtime-native fallbacks.
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -7,7 +7,7 @@ This framework is the single place Spotlight models external tools. Integrations
 ## Why integrations are separate from skills
 
 - **Skills** are methodology playbooks: how to investigate a person, how to follow the money, how to verify a claim. Runtime-agnostic, no credentials.
-- **Integrations** are specific external tools with credentials and an API contract: Junkipedia's narrative database, OSINT Navigator's tool index, Unpaywall's DOI lookup, browser-use for AI-driven browser automation.
+- **Integrations** are specific external tools with credentials and an API contract: Junkipedia's narrative database, OSINT Navigator's tool index, Phantom Tide's transport-intelligence API, Unpaywall's DOI lookup, browser-use for AI-driven browser automation.
 
 An agent invokes a skill to get *guidance*; it calls an integration to get *data*.
 
@@ -18,6 +18,7 @@ An agent invokes a skill to get *guidance*; it calls an integration to get *data
 | `browser-use` | browser-automation | No (OSS); optional cloud | `BROWSER_USE_API_KEY` (optional) |
 | `junkipedia` | social-osint | Yes | `JUNKIPEDIA_API_KEY` |
 | `osint-navigator` | tool-discovery | Yes | `OSINT_NAV_API_KEY` |
+| `phantom-tide` | transport-intelligence | Yes | `PHANTOM_TIDE_API_KEY` |
 | `scoutpost` | monitoring | Yes | `SCOUTPOST_API_KEY` |
 | `unpaywall` | academic-open-access | Yes | `UNPAYWALL_EMAIL` |
 

--- a/integrations/phantom-tide/integration.md
+++ b/integrations/phantom-tide/integration.md
@@ -1,0 +1,142 @@
+# Phantom Tide Integration
+
+Phantom Tide is a transport-intelligence API and analyst surface for maritime and airspace signals. Use it to turn cross-domain movement anomalies into leads, then corroborate them with primary sources such as flight/vessel registries, ADS-B/AIS history, official notices, sanctions lists, port records, satellite imagery, and archived source material.
+
+## Confirmed Surface
+
+The currently confirmed machine-consumable endpoint is:
+
+```text
+GET https://phantom.labs.jamessawyer.co.uk/api/public/aircraft/restricted-airspace-crossings
+```
+
+It returns restricted-airspace crossing candidates with event IDs, timestamps, aircraft identifiers, airspace metadata, coordinates, source freshness, reference-layer state, and contract notes.
+
+Treat these records as **candidate movement context**, not as proof of wrongdoing, regulatory breach, or live enforcement alert. The endpoint contract explicitly says entries are replay/archive-derived candidates and should be used as ingestion or showcase context.
+
+## Environment
+
+Requires:
+
+```bash
+PHANTOM_TIDE_API_KEY=pt_...
+```
+
+Do not print the key. Store it in `.env` only.
+
+## When To Use
+
+Use Phantom Tide when an investigation involves:
+
+- aircraft entering, exiting, or traversing restricted/special-use airspace;
+- transport activity near conflict zones, maritime chokepoints, infrastructure, sanctions targets, or official warning areas;
+- a need to distinguish live, stale, degraded, tier-limited, or partial transport context;
+- a lead where multiple weak transport signals may converge into a stronger question.
+
+Do not use Phantom Tide as a sole source for publication-grade findings. Use it to generate or prioritize leads, then corroborate with independent source trails.
+
+## Aircraft Restricted-Airspace Query
+
+Validate case slugs and output paths before constructing command strings. Do not interpolate untrusted user text into shell commands.
+
+```bash
+python3 scripts/spotlight_safe.py validate-slug "{project_slug}"
+curl --get "https://phantom.labs.jamessawyer.co.uk/api/public/aircraft/restricted-airspace-crossings" \
+  -H "Authorization: Bearer ${PHANTOM_TIDE_API_KEY}" \
+  --data-urlencode "hours=24" \
+  --data-urlencode "limit=100" \
+  --data-urlencode "include_meta=true" \
+  -o "cases/{project}/research/phantom-tide-airspace-{timestamp}.json"
+```
+
+For polling, use the returned watermark:
+
+```bash
+curl --get "https://phantom.labs.jamessawyer.co.uk/api/public/aircraft/restricted-airspace-crossings" \
+  -H "Authorization: Bearer ${PHANTOM_TIDE_API_KEY}" \
+  --data-urlencode "sample_after={poll_after}" \
+  --data-urlencode "include_meta=true" \
+  -o "cases/{project}/research/phantom-tide-airspace-after-{timestamp}.json"
+```
+
+## Output Handling
+
+Save raw responses under:
+
+```text
+cases/{project}/research/phantom-tide-<query-kind>-<slug>-<timestamp>.json
+```
+
+When folding records into findings, preserve:
+
+- `event_id`
+- `when`
+- `who.icao24`
+- `who.callsign`
+- `what.transition`
+- `what.airspace.name`
+- `what.airspace.restriction_label`
+- `where.lat`
+- `where.lon`
+- `quality.status`
+- `data_freshness.status`
+- `reference_layer.source_snapshots[]`
+- `contract.notes[]`
+
+Evidence entries should state:
+
+```json
+{
+  "access_method": "api",
+  "access_notes": "Retrieved via Phantom Tide API as candidate transport context; corroboration required before publication."
+}
+```
+
+Confidence caps:
+
+- `low` if Phantom Tide is the only source.
+- `medium` if an independent ADS-B/AIS/official-notice trail supports the event timing and geometry.
+- `high` only if primary records or authoritative archives corroborate the movement and the claim wording avoids overstating intent or violation.
+
+## Maritime And Area Intelligence
+
+The public docs and repository describe maritime capabilities such as AIS context, vessel formations, DSC communications, vessel-linked detail context, chokepoint context, proximity query, Area Intelligence Report, and convergence zones. These are highly relevant to Spotlight, but no stable public API contract for those routes is confirmed yet.
+
+Until Phantom Tide provides endpoint docs, do not claim direct maritime support beyond what a user can manually inspect in the UI. Record these as desired API capabilities:
+
+- vessel lookup by MMSI, IMO, name, callsign;
+- vessel position/history window;
+- vessel-in-zone and chokepoint proximity;
+- DSC communications linked to vessels or coast stations;
+- convergence-zone query by bounding box, point/radius, or time window;
+- Area Intelligence Report by point/radius;
+- source health and tier state for every response.
+
+## Source-State Reading
+
+Phantom Tide distinguishes:
+
+- `Live`: current ingest succeeded.
+- `Degraded`: the source answered but completeness or quality fell.
+- `Stale`: cached/old data remains visible for continuity.
+- `Tier-limited`: the feature exists but the current access tier is capped.
+- `Partial`: some sources or historical windows are incomplete.
+
+Never treat an empty or partial response as proof of absence until source state, time window, zoom/area scope, access tier, and freshness have been checked.
+
+## Sensitive Mode
+
+Phantom Tide is a remote API. Do not call it when sensitive mode strips remote fetch/search behavior. Pre-cached JSON responses may still be read locally and cited as previously acquired material if the acquisition time and source state are preserved.
+
+## Developer API Gaps
+
+Ask Phantom Tide for:
+
+- OpenAPI schema or endpoint docs for all keyed routes.
+- Auth header format and key scopes.
+- Rate limits, pagination, and backoff semantics.
+- Stable response schemas for aircraft, vessel, DSC, convergence, proximity, and area-report routes.
+- Watermark fields for polling.
+- Freshness/source-health fields guaranteed on every endpoint.
+- Error taxonomy for tier limits, stale data, partial data, empty windows, invalid geometry, and unavailable upstreams.
+- Terms for storing raw responses in local Spotlight case folders.

--- a/integrations/phantom-tide/manifest.json
+++ b/integrations/phantom-tide/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "phantom-tide",
+  "name": "Phantom Tide",
+  "description": "Cross-domain maritime and airspace intelligence API for restricted-airspace crossing candidates, source freshness, and future vessel/area intelligence workflows.",
+  "category": "transport-intelligence",
+  "type": "api",
+  "requires_key": true,
+  "env_vars": ["PHANTOM_TIDE_API_KEY"],
+  "capabilities": [
+    "aircraft-restricted-airspace-crossings",
+    "transport-anomaly-triage",
+    "source-freshness-context",
+    "maritime-area-context-planned",
+    "vessel-intelligence-planned",
+    "convergence-analysis-planned"
+  ],
+  "invocable_by": ["investigator", "fact-checker"],
+  "homepage": "https://phantom.labs.jamessawyer.co.uk/",
+  "docs": "https://phantom.labs.jamessawyer.co.uk/docs/guide/",
+  "rate_limit_note": "Opt-in API key access. Current confirmed public endpoint is bounded and pollable; ask Phantom Tide for private endpoint quotas before enabling maritime/convergence calls."
+}

--- a/integrations/preflight.py
+++ b/integrations/preflight.py
@@ -22,6 +22,7 @@ import shutil
 import sys
 import urllib.error
 import urllib.request
+import os
 from pathlib import Path
 
 # Import the shared helpers from integrations/ — local single source of truth
@@ -42,6 +43,21 @@ def smoke_test(manifest: dict) -> tuple[bool, str | None]:
     kind = manifest.get("type", "api")
 
     if kind == "api":
+        if manifest.get("id") == "phantom-tide":
+            key = os.environ.get("PHANTOM_TIDE_API_KEY", "")
+            url = "https://phantom.labs.jamessawyer.co.uk/api/public/aircraft/restricted-airspace-crossings?hours=24&limit=1&include_meta=true"
+            headers = {"User-Agent": "Spotlight-Preflight/1.0"}
+            if key:
+                headers["Authorization"] = f"Bearer {key}"
+            try:
+                req = urllib.request.Request(url, method="GET", headers=headers)
+                with urllib.request.urlopen(req, timeout=8) as resp:
+                    return (200 <= resp.status < 400), None
+            except urllib.error.HTTPError as e:
+                return False, f"HTTP {e.code}"
+            except Exception as e:
+                return False, f"{type(e).__name__}: {e}"
+
         url = manifest.get("homepage") or manifest.get("docs")
         if not url:
             return True, None

--- a/setup.html
+++ b/setup.html
@@ -1328,6 +1328,14 @@
           <label class="block">Unpaywall email <span class="hint">— sent to Unpaywall as a fair-use contact; never stored by us.</span></label>
           <input type="text" id="unpaywall_email" placeholder="you@example.com" autocomplete="off">
         </div>
+
+        <div class="checkbox-group" style="margin-top: 12px;">
+          <label><input type="checkbox" id="int_phantom_tide"><span class="opt-name"><span class="name">Phantom Tide</span><span class="desc">Transport intelligence for restricted-airspace crossing candidates and source freshness. Maritime/convergence API support is pending a stable endpoint contract.</span></span></label>
+        </div>
+        <div id="phantom_tide_keys" class="hidden" style="margin-top: 16px;">
+          <label class="block">Phantom Tide API key <span class="hint">— bring your own key; never stored by us.</span></label>
+          <input type="password" id="phantom_tide_key" placeholder="pt_..." autocomplete="off">
+        </div>
       </section>
 
       <div class="generate-bar">
@@ -1609,6 +1617,7 @@
   }
   bindCheckbox('int_junkipedia', 'junkipedia_keys');
   bindCheckbox('int_unpaywall', 'unpaywall_keys');
+  bindCheckbox('int_phantom_tide', 'phantom_tide_keys');
 
   function collectForm() {
     const mode = document.querySelector('input[name="mode"]:checked').value;
@@ -1642,6 +1651,8 @@
       junkipedia_key: document.getElementById('junkipedia_key').value.trim(),
       int_unpaywall: document.getElementById('int_unpaywall').checked,
       unpaywall_email: document.getElementById('unpaywall_email').value.trim(),
+      int_phantom_tide: document.getElementById('int_phantom_tide').checked,
+      phantom_tide_key: document.getElementById('phantom_tide_key').value.trim(),
     };
   }
 
@@ -2057,6 +2068,9 @@
     if (cfg.int_unpaywall && cfg.unpaywall_email) {
       p('write_env_var UNPAYWALL_EMAIL ' + shellEscape(cfg.unpaywall_email));
     }
+    if (cfg.int_phantom_tide && cfg.phantom_tide_key) {
+      p('write_env_var PHANTOM_TIDE_API_KEY ' + shellEscape(cfg.phantom_tide_key));
+    }
     if (cfg.mode === 'local') {
       p('write_env_var MODEL_REPO ' + shellEscape(cfg.model_repo));
       p('write_env_var LOCAL_SERVER ' + shellEscape(cfg.local_server || 'llamacpp'));
@@ -2082,7 +2096,8 @@
     p('    "osint_navigator": true,');
     p('    "junkipedia": ' + (cfg.int_junkipedia ? 'true' : 'false') + ',');
     p('    "browser_use": ' + (cfg.int_browseruse ? 'true' : 'false') + ',');
-    p('    "unpaywall": ' + (cfg.int_unpaywall ? 'true' : 'false'));
+    p('    "unpaywall": ' + (cfg.int_unpaywall ? 'true' : 'false') + ',');
+    p('    "phantom_tide": ' + (cfg.int_phantom_tide ? 'true' : 'false'));
     p('  },');
     p('  "created_at": "' + new Date().toISOString() + '",');
     p('  "last_used": "' + new Date().toISOString() + '"');
@@ -2173,6 +2188,7 @@
     if (cfg.cloud_key_var) p('check_env_name ' + cfg.cloud_key_var);
     if (cfg.int_junkipedia) p('check_env_name JUNKIPEDIA_API_KEY');
     if (cfg.int_unpaywall) p('check_env_name UNPAYWALL_EMAIL');
+    if (cfg.int_phantom_tide) p('check_env_name PHANTOM_TIDE_API_KEY');
     p('if [ -x "$SPOTLIGHT_DIR/tests/smoke.sh" ]; then (cd "$SPOTLIGHT_DIR" && bash tests/smoke.sh >/dev/null) && ok "Smoke test" || bad "Smoke test failed"; fi');
     p('if [ -x "$SPOTLIGHT_DIR/integrations/preflight.py" ] || [ -f "$SPOTLIGHT_DIR/integrations/preflight.py" ]; then (cd "$SPOTLIGHT_DIR" && set -a && . .env && set +a && python3 integrations/preflight.py --text >/dev/null) && ok "Integration preflight" || bad "Integration preflight reported issues"; fi');
     p('if [ "$fail" -eq 0 ]; then printf "\\nSpotlight doctor: OK\\n"; else printf "\\nSpotlight doctor: failed\\n"; fi');
@@ -2418,6 +2434,7 @@
     if (cfg.mode === 'cloud' && cfg.cloud_key_var) values[cfg.cloud_key_var] = cfg.cloud_key || '';
     if (cfg.int_junkipedia) values.JUNKIPEDIA_API_KEY = cfg.junkipedia_key || '';
     if (cfg.int_unpaywall) values.UNPAYWALL_EMAIL = cfg.unpaywall_email || '';
+    if (cfg.int_phantom_tide) values.PHANTOM_TIDE_API_KEY = cfg.phantom_tide_key || '';
     if (cfg.mode === 'local') {
       values.MODEL_REPO = cfg.model_repo || '';
       values.LOCAL_SERVER = cfg.local_server || 'llamacpp';
@@ -2448,6 +2465,7 @@
         optional: [
           ...(cfg.int_junkipedia ? ['JUNKIPEDIA_API_KEY'] : []),
           ...(cfg.int_unpaywall ? ['UNPAYWALL_EMAIL'] : []),
+          ...(cfg.int_phantom_tide ? ['PHANTOM_TIDE_API_KEY'] : []),
         ],
         values: envValues(cfg),
       },
@@ -2456,6 +2474,7 @@
         browser_use: cfg.int_browseruse,
         junkipedia: cfg.int_junkipedia,
         unpaywall: cfg.int_unpaywall,
+        phantom_tide: cfg.int_phantom_tide,
       },
       notes: [
         'This manifest contains local secret values from the setup form.',

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrations
-description: Routing table for external tool integrations — browser-use, Junkipedia, OSINT Navigator, Scoutpost, and more. Agents invoke this skill to discover which integrations are live and which one fits a given investigation task.
+description: Routing table for external tool integrations — browser-use, Junkipedia, OSINT Navigator, Phantom Tide, Scoutpost, and more. Agents invoke this skill to discover which integrations are live and which one fits a given investigation task.
 version: "1.0"
 invocable_by: [investigator, fact-checker, orchestrator]
 requires: []
@@ -27,6 +27,7 @@ The skill is cheap to load — it's a routing table, not a deep methodology guid
 | `browser-use` | browser-automation | form-navigation, search-export, login-driving, multi-step-browsing | Complex form submissions, pagination beyond firecrawl, agent-driven site navigation. NOT for chain-of-custody evidence (use `dev-browser`). |
 | `junkipedia` | social-osint | narrative-tracking, misinformation-search, social-media-monitoring, cross-platform-query | Tracking how a claim spread; finding social posts deleted from origin; cross-platform narrative investigation. |
 | `osint-navigator` | tool-discovery | tool-search-by-keyword, complex-query-synthesis, country-specific-tool-lookup | When the curated 150-tool catalog in `skills/osint/references/tools-by-category.md` doesn't have what you need. |
+| `phantom-tide` | transport-intelligence | aircraft-restricted-airspace-crossings, transport-anomaly-triage, source-freshness-context | Aircraft restricted-airspace crossing candidates and transport anomaly context. Maritime/convergence support is planned but requires a confirmed API contract. |
 | `scoutpost` | monitoring | project-scoped-monitoring, scout-creation, information-unit-retrieval, scheduled-monitoring | Approved monitoring that should keep running after the current investigation cycle. |
 | `unpaywall` | academic-open-access | doi-open-access-lookup, academic-fulltext-discovery, legal-pdf-location | Academic papers with DOIs when the content-access hierarchy needs a legal open-access copy. |
 
@@ -46,6 +47,11 @@ What's the task?
 ├── "Need a tool I don't know for category X" / "Compare tools" / "Niche country-specific tool"
 │     → osint-navigator  (if green — check preflight)
 │     → fallback: skills/osint/references/tools-by-category.md (offline, 150 tools)
+│
+├── "Aircraft crossed restricted/special-use airspace" / "Transport anomaly near a maritime or airspace area"
+│     → phantom-tide  (if green — check preflight)
+│     → use confirmed aircraft restricted-airspace feed today
+│     → for maritime/convergence, use only if Phantom Tide provides endpoint docs; otherwise record as manual/UI context and corroborate externally
 │
 ├── "Static page scrape / web search"
 │     → fetch / search (verbs, no integration needed)

--- a/tests/eval.sh
+++ b/tests/eval.sh
@@ -136,6 +136,15 @@ else
 fi
 
 echo ""
+echo "── Preflight regression ──"
+
+if python3 tests/preflight-check.py >/dev/null 2>&1; then
+  ok "integration preflight behavior is stable"
+else
+  fail "integration preflight regression failed"
+fi
+
+echo ""
 if [ $FAIL -eq 0 ]; then
   printf "%s✓ All %d eval checks passed%s\n" "$_c_green" "$PASS" "$_c_reset"
   exit 0

--- a/tests/preflight-check.py
+++ b/tests/preflight-check.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Stable unit checks for integration preflight behavior."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "integrations"))
+
+from integrations import preflight  # noqa: E402
+from _preflight_base import build_report  # noqa: E402
+
+
+class FakeResponse:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+class PreflightCheck(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = {
+            "id": "phantom-tide",
+            "name": "Phantom Tide",
+            "category": "transport-intelligence",
+            "type": "api",
+            "requires_key": True,
+            "env_vars": ["PHANTOM_TIDE_API_KEY"],
+        }
+        self._old_key = os.environ.pop("PHANTOM_TIDE_API_KEY", None)
+
+    def tearDown(self) -> None:
+        if self._old_key is not None:
+            os.environ["PHANTOM_TIDE_API_KEY"] = self._old_key
+        else:
+            os.environ.pop("PHANTOM_TIDE_API_KEY", None)
+
+    def test_phantom_tide_is_red_without_key(self) -> None:
+        report = build_report(self.manifest, smoke_fn=preflight.smoke_test)
+
+        self.assertEqual(report["status"], "red")
+        self.assertEqual(report["env_vars_missing"], ["PHANTOM_TIDE_API_KEY"])
+
+    def test_phantom_tide_smoke_uses_keyed_airspace_endpoint(self) -> None:
+        os.environ["PHANTOM_TIDE_API_KEY"] = "pt-test"
+        captured = {}
+
+        def fake_urlopen(req, timeout):
+            captured["url"] = req.full_url
+            captured["timeout"] = timeout
+            captured["authorization"] = req.get_header("Authorization")
+            return FakeResponse()
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            report = build_report(self.manifest, smoke_fn=preflight.smoke_test)
+
+        self.assertEqual(report["status"], "green")
+        self.assertIn("/api/public/aircraft/restricted-airspace-crossings", captured["url"])
+        self.assertIn("limit=1", captured["url"])
+        self.assertEqual(captured["authorization"], "Bearer pt-test")
+        self.assertEqual(captured["timeout"], 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/setup-generator-check.js
+++ b/tests/setup-generator-check.js
@@ -81,6 +81,8 @@ const baseCfg = {
   junkipedia_key: "",
   int_unpaywall: false,
   unpaywall_email: "",
+  int_phantom_tide: false,
+  phantom_tide_key: "",
 };
 
 const configs = [
@@ -222,6 +224,8 @@ const manifestCfg = {
   cloud_key_var: "FIREWORKS_API_KEY",
   int_junkipedia: true,
   junkipedia_key: "junk-secret-test",
+  int_phantom_tide: true,
+  phantom_tide_key: "pt-secret-test",
 };
 const manifest = buildAgentManifest(manifestCfg);
 const prompt = buildAgentPrompt(manifest);
@@ -229,11 +233,12 @@ if (
   manifest.env.values.FIRECRAWL_API_KEY !== "fc-test" ||
   manifest.env.values.OSINT_NAV_API_KEY !== "on-test" ||
   manifest.env.values.FIREWORKS_API_KEY !== "fw-secret-test" ||
-  manifest.env.values.JUNKIPEDIA_API_KEY !== "junk-secret-test"
+  manifest.env.values.JUNKIPEDIA_API_KEY !== "junk-secret-test" ||
+  manifest.env.values.PHANTOM_TIDE_API_KEY !== "pt-secret-test"
 ) {
   console.log("✗ agent manifest missing local secret values");
   fail++;
-} else if (prompt.includes("fw-secret-test") || prompt.includes("junk-secret-test")) {
+} else if (prompt.includes("fw-secret-test") || prompt.includes("junk-secret-test") || prompt.includes("pt-secret-test")) {
   console.log("✗ agent prompt printed secret values");
   fail++;
 } else if (!prompt.includes("Handle the setup for the user") || !prompt.includes("env.values")) {


### PR DESCRIPTION
## What changed
Adds Phantom Tide as an opt-in Spotlight plugin after Unpaywall and OSINT Navigator.

- adds the Phantom Tide integration manifest and investigation playbook
- wires setup generation for optional PHANTOM_TIDE_API_KEY storage and redaction
- adds preflight support for the confirmed restricted-airspace endpoint
- updates integration routing/docs so transport anomaly work can call Phantom Tide as lead context
- adds stable regression coverage for Phantom Tide preflight behavior

## Validation
- node tests/setup-generator-check.js
- bash tests/smoke.sh
- PATH="$PWD/.venv/bin:$PATH" bash tests/eval.sh
- git diff --check

## Scope note
This PR is only the Phantom Tide plugin. The broader Spotlight hardening and provenance work is isolated in PR #26.