### PR TITLE
Extract install logic to install-spotlight.sh + add Pi as second local agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ An **agnostic port** of the `buriedsignals/spotlight@1.2.1` and `buriedsignals/o
 
 | Runtime | Status | How it loads |
 |---|---|---|
-| **opencode** (https://opencode.ai) | Primary local — native support | `brew install opencode` (CLI) or `brew install --cask opencode-desktop` (GUI). Symlink loop into `~/.config/opencode/skills/`. `AGENTS.md`, sub-agents, MCP all native. Pair with `llama.cpp` provider for fully-local Qwen via llama-server. |
+| **opencode** (https://opencode.ai) | Primary local agent — native sub-agents | `brew install opencode` (CLI) or `brew install --cask opencode-desktop` (GUI). Symlink loop into `~/.config/opencode/skills/`. `AGENTS.md`, sub-agents, MCP all native. Pair with `llama.cpp` provider for fully-local Qwen via llama-server. |
+| **pi** (https://pi.dev) | Alternative local agent — no sub-agents | `npm install -g @mariozechner/pi-coding-agent` + `pi install npm:pi-llama-cpp`. setup.html offers this as a second local agent. Investigator + fact-checker share one context — weaker independence than opencode. |
 | **Claude Code** | Install package | `npm install -g @anthropic-ai/claude-code`; runs from repo dir |
 | **Codex CLI** | Install package | `npm install -g @openai/codex`; reads `AGENTS.md` natively |
 | **Gemini CLI** | Install package | `npm install -g @google/gemini-cli`; symlink `GEMINI.md → AGENTS.md` |
 | **Hermes** (Mycroft / Mac Mini) | Production | `skills.external_dirs` in `~/.hermes/config.yaml` |
 | **Goose** | Extension pack | `goose extensions install spotlight` |
-| **pi** (https://pi.dev) | Local — single-context fallback | `mkdir -p ~/.pi/agent/skills && ln -sfn /path/to/spotlight/skills ~/.pi/agent/skills/spotlight`. No native sub-agents, so investigator/fact-checker run in the main session. Use opencode for the full pipeline. |
 
 Per-runtime wiring: **[docs/runtimes.md](docs/runtimes.md)**.
 
@@ -69,7 +69,7 @@ Optional:
 - **JUNKIPEDIA_API_KEY** — for narrative / misinformation tracking (application-based at junkipedia.org).
 - **CORE_API_KEY** — for academic paper access in `content-access` skill.
 - **NOOSPHERE_C2PA_URL** — optional local or hosted Noosphere signer endpoint for C2PA provenance signing; no API key is required, but the signer must have its own signing credential configured.
-- **Inference backend (for Local runtime)** — `brew install llama.cpp` (lean, what setup.html defaults to) or `brew install ollama` (CLI-first model manager).
+- **Inference backend (for Local mode)** — `brew install llama.cpp` (lean, what setup.html defaults to) or `brew install ollama` (CLI-first model manager). Orthogonal to the agent choice: pick one of each. setup.html offers **opencode** (recommended, native sub-agents) or **Pi** (minimal, `pi install npm:pi-llama-cpp` extension) as the agent layer.
 
 ## Documentation
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -144,7 +144,7 @@ Enforce at the agent definition: strip `firecrawl` (and any external-fetch shell
 
 **What it is:** Minimal TypeScript coding harness by Mario Zechner (https://pi.dev). MIT license. `npm install -g @mariozechner/pi-coding-agent`. Natively supports `AGENTS.md` + `skills/*/SKILL.md`.
 
-**Status:** Local fallback. opencode (above) is the recommended local Spotlight runtime — pi lacks native sub-agents (so investigator + fact-checker run single-context) and needs an extension to talk to llama-server. Use pi only if you already have it set up or specifically want its minimal surface.
+**Status:** Local alternative. opencode (above) remains the recommended local Spotlight runtime because pi lacks native sub-agents (so investigator + fact-checker run single-context, weakening the verification independence guarantee). Spotlight's installer (`setup.html` → `install-spotlight.sh`) offers pi as an explicit second choice — picked it when you want a leaner install and accept the sub-agent trade-off.
 
 ### Loading this repo
 
@@ -168,32 +168,24 @@ pi ships native `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Bash` equivalents. The
 
 ### Local llama-server provider via pi
 
-pi v0.70 does **not** accept arbitrary OpenAI-compatible providers via `~/.pi/agent/models.json` — only known providers (OpenAI, Anthropic, Google) can be extended there. To route inference to a local server (llama-server, Ollama, vLLM, Exoscale), write a pi extension that calls `pi.registerProvider("local", { baseUrl, api: "openai-completions", models: [...] })`. Reference: `docs/custom-provider.md` in the pi package, plus the worked example at `examples/extensions/custom-provider-qwen-cli/`.
+Use the `pi-llama-cpp` extension — a community package by `gsanhueza` (MIT, v0.4.0 as of May 2026), listed on Pi's official package registry at https://pi.dev/packages/pi-llama-cpp:
 
-Minimal extension (TypeScript) — ship as a standalone npm package or drop under `~/.pi/agent/extensions/`:
-
-```typescript
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-
-export default function (pi: ExtensionAPI) {
-  pi.registerProvider("local", {
-    baseUrl: "http://127.0.0.1:8080/v1",     // llama-server (or 11434 for Ollama)
-    apiKey: "unused",
-    api: "openai-completions",
-    models: [{
-      id: "qwen27",
-      name: "Qwen3.6-27B Uncensored (local)",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 262144,
-      maxTokens: 16384
-    }]
-  });
-}
+```bash
+pi install npm:pi-llama-cpp
 ```
 
-Then `pi --provider local --model qwen27`. opencode's native `llama.cpp` provider does this same job with one JSON block — no extension code.
+The extension auto-detects models on the running llama-server (`/models` endpoint), supports load/unload/switch via `/models` slash command, and resolves the endpoint URL from any of:
+
+1. `.pi/llama-server.json` in the project root — `{"url":"http://127.0.0.1:8080"}`
+2. `LLAMA_SERVER_URL` env var
+3. `~/.pi/agent/settings.json` — `{"llamaServerUrl":"http://127.0.0.1:8080"}`
+4. Default `http://127.0.0.1:8080`
+
+Spotlight's installer writes option 3 automatically when you pick Pi as the agent harness — pointing at port 8080 for `llamacpp` or 11434 for Ollama. Pi's authentication for the local server (if any) lives in `~/.pi/agent/auth.json` under provider id `llama-server` (displayed as "Llama.cpp" in the Pi UI).
+
+Status indicators on the `/models` browser: 🟢 loaded · 🟡 loading · 🔴 failed · 🔵 sleeping · ⚪ unloaded. The sleeping state requires `llama-server --sleep-idle-seconds <n>` on the server side.
+
+opencode's native `llama.cpp` provider does the same model-browsing job via one JSON block in `opencode.json` — no extension. Either path connects an agent to the same OpenAI-compatible endpoint; pick the agent based on whether you need native sub-agents.
 
 **Current Spotlight operator model**: `unsloth/gemma-4-26B-A4B-it-GGUF` on Hugging Face (base Gemma 4 26B A4B — we evaluated a journalism fine-tune but the base outperformed it on tool-use + document OCR). Multimodal (text + vision) VLM MoE — 26B total / 4B active. Native vision for scanned court documents, satellite imagery, and screenshots. Recommended quants:
 - `gemma-4-26B-A4B-it-UD-Q6_K_XL.gguf` (~22 GB) + `mmproj-BF16.gguf` (~1.2 GB) — 48GB+ Macs

--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -1,0 +1,936 @@
+#!/usr/bin/env bash
+# Spotlight installer — runs the same end-to-end install as the legacy
+# setup.html generator, but as a static, version-controlled script.
+#
+# Driven by SPOTLIGHT_CONFIG: a base64-encoded block of `export KEY='value'`
+# lines built by setup.html's buildExportBlock() helper. The block is decoded
+# with `eval` — safety relies on the JS-side shellEscape() single-quoting
+# every value before joining.
+#
+# Two delivery paths converge here:
+#   curl -fsSL .../install-spotlight.sh | SPOTLIGHT_CONFIG='<b64>' bash
+#   <generated .command file>  →  exports SPOTLIGHT_CONFIG then curls this.
+
+set -euo pipefail
+
+if [ -z "${SPOTLIGHT_CONFIG:-}" ]; then
+  echo "SPOTLIGHT_CONFIG env var is required (base64-encoded shell export block)" >&2
+  echo "Open setup.html in a browser to generate the install one-liner." >&2
+  exit 1
+fi
+
+eval "$(printf '%s' "$SPOTLIGHT_CONFIG" | base64 -d)"
+
+# Dry-run mode prints what would happen without touching the system.
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    *) ;;
+  esac
+done
+
+run() {
+  if [ "$DRY_RUN" = "1" ]; then
+    printf 'DRY-RUN: %s\n' "$*"
+  else
+    "$@"
+  fi
+}
+
+# === expand_path: handle ~ and ~/ in the form-supplied paths ===
+expand_path() {
+  local input="$1"
+  if [ "$input" = "~" ]; then printf "%s\n" "$HOME"
+  elif [[ "$input" == "~/"* ]]; then printf "%s/%s\n" "$HOME" "${input#~/}"
+  else printf "%s\n" "$input"; fi
+}
+
+SPOTLIGHT_DIR_INPUT="${SPOTLIGHT_DIR_INPUT:?install path missing from config}"
+if [ -n "${SPOTLIGHT_DIR:-}" ]; then
+  SPOTLIGHT_DIR="$SPOTLIGHT_DIR"
+else
+  SPOTLIGHT_DIR="$(expand_path "$SPOTLIGHT_DIR_INPUT")"
+fi
+SPOTLIGHT_VAULT_INPUT="${SPOTLIGHT_VAULT_INPUT:?vault path missing from config}"
+SPOTLIGHT_VAULT_PATH="$(expand_path "$SPOTLIGHT_VAULT_INPUT")"
+SPOTLIGHT_CASES_ROOT="$SPOTLIGHT_VAULT_PATH/cases"
+REPO_URL="https://github.com/buriedsignals/spotlight.git"
+export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
+
+# Defaults for optional config fields
+: "${SPOTLIGHT_MODE:=cloud}"
+: "${SPOTLIGHT_RUNTIME:=claude}"
+: "${SPOTLIGHT_LOCAL_SERVER:=}"
+: "${SPOTLIGHT_LOCAL_MODEL:=gemma}"
+: "${SPOTLIGHT_AGENT:=opencode}"
+: "${SPOTLIGHT_OPENCODE_INTERFACE:=cli}"
+: "${SPOTLIGHT_OPENCODE_PROVIDER:=}"
+: "${SPOTLIGHT_CLOUD_KEY_VAR:=}"
+: "${SPOTLIGHT_CLOUD_KEY:=}"
+: "${SPOTLIGHT_MODEL_REPO:=}"
+: "${SPOTLIGHT_VAULT_APP:=obsidian}"
+: "${SPOTLIGHT_INT_BROWSERUSE:=false}"
+: "${SPOTLIGHT_INT_JUNKIPEDIA:=false}"
+: "${JUNKIPEDIA_API_KEY:=}"
+: "${SPOTLIGHT_INT_UNPAYWALL:=false}"
+: "${UNPAYWALL_EMAIL:=}"
+: "${FIRECRAWL_API_KEY:?firecrawl key missing from config}"
+: "${OSINT_NAV_API_KEY:?osint-navigator key missing from config}"
+
+# Derive model artifact names from the model selection.
+case "$SPOTLIGHT_LOCAL_MODEL" in
+  gemma)
+    GGUF_FILE="gemma-4-26B-A4B-it-UD-Q4_K_M.gguf"
+    OLLAMA_MODEL_DEFAULT="hf.co/unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M"
+    OLLAMA_ALIAS_DEFAULT="spotlight-gemma4-q4"
+    OLLAMA_SIZE_LABEL="~8 GB"
+    ;;
+  qwen27b)
+    GGUF_FILE="Qwen3.6-27B-Uncensored-HauhauCS-Aggressive-Q4_K_P.gguf"
+    OLLAMA_MODEL_DEFAULT="hf.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive:IQ2_M"
+    OLLAMA_ALIAS_DEFAULT="spotlight-qwen36-27b-q4"
+    OLLAMA_SIZE_LABEL="~10 GB"
+    ;;
+  *)
+    GGUF_FILE=""
+    OLLAMA_MODEL_DEFAULT=""
+    OLLAMA_ALIAS_DEFAULT=""
+    OLLAMA_SIZE_LABEL=""
+    ;;
+esac
+
+if [ "$SPOTLIGHT_LOCAL_SERVER" = "llamacpp" ]; then
+  LOCAL_PORT="8080"
+elif [ "$SPOTLIGHT_LOCAL_SERVER" = "ollama" ]; then
+  LOCAL_PORT="11434"
+else
+  LOCAL_PORT=""
+fi
+LOCAL_BASE_URL=""
+if [ -n "$LOCAL_PORT" ]; then
+  LOCAL_BASE_URL="http://127.0.0.1:$LOCAL_PORT/v1"
+fi
+MODEL_LEAF=""
+if [ -n "$SPOTLIGHT_MODEL_REPO" ]; then
+  MODEL_LEAF="${SPOTLIGHT_MODEL_REPO##*/}"
+fi
+
+# === Colors + spinner + step headers (verbatim from buildScript) ===
+_c_reset=$'\033[0m'; _c_cyan=$'\033[36m'; _c_green=$'\033[32m'; _c_red=$'\033[31m'; _c_dim=$'\033[2m'; _c_bold=$'\033[1m'
+_spin_frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
+
+spin() {
+  local msg="$1"; shift
+  if [ "$DRY_RUN" = "1" ]; then
+    printf 'DRY-RUN: %s — %s\n' "$msg" "$*"
+    return 0
+  fi
+  local tmpfile; tmpfile="$(mktemp)"
+  ( "$@" ) >"$tmpfile" 2>&1 &
+  local pid=$!
+  local i=0 n=${#_spin_frames[@]}
+  printf "\033[?25l" 2>/dev/null || true
+  while kill -0 $pid 2>/dev/null; do
+    printf "\r\033[K%s%s%s %s" "$_c_cyan" "${_spin_frames[$((i % n))]}" "$_c_reset" "$msg"
+    i=$((i + 1))
+    sleep 0.08
+  done
+  wait $pid 2>/dev/null; local status=$?
+  printf "\033[?25h" 2>/dev/null || true
+  if [ $status -eq 0 ]; then
+    printf "\r\033[K%s✓%s %s\n" "$_c_green" "$_c_reset" "$msg"
+  else
+    printf "\r\033[K%s✗%s %s\n" "$_c_red" "$_c_reset" "$msg"
+    echo "$_c_dim─── output ───$_c_reset"
+    cat "$tmpfile"
+  fi
+  rm -f "$tmpfile"
+  return $status
+}
+
+step() { printf "\n%s%s━━ %s ━━%s\n" "$_c_bold" "$_c_cyan" "$1" "$_c_reset"; }
+
+echo ""
+echo "${_c_bold}${_c_cyan}  ╔════════════════════════════════════════════════╗${_c_reset}"
+echo "${_c_bold}${_c_cyan}  ║           Spotlight installer                  ║${_c_reset}"
+echo "${_c_bold}${_c_cyan}  ╚════════════════════════════════════════════════╝${_c_reset}"
+echo ""
+
+OS="$(uname -s)"
+if [ "$OS" != "Darwin" ] && [ "$OS" != "Linux" ]; then
+  echo "Unsupported OS: $OS. macOS or Linux required (Windows: use WSL)." >&2
+  exit 1
+fi
+
+step "Prerequisites"
+
+ensure_brew() {
+  if command -v brew >/dev/null 2>&1; then
+    printf "%s✓%s Homebrew present\n" "$_c_green" "$_c_reset"; return 0
+  fi
+  echo ""
+  echo "Homebrew is needed to install other tools. Install it now? [Y/n]"
+  read -r ans </dev/tty || ans="Y"
+  if [[ "$ans" =~ ^[Nn] ]]; then echo "Aborted." >&2; exit 1; fi
+  run /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  [ -x /opt/homebrew/bin/brew ] && eval "$(/opt/homebrew/bin/brew shellenv)"
+  [ -x /usr/local/bin/brew ] && eval "$(/usr/local/bin/brew shellenv)"
+}
+
+ensure_tool() {
+  local cmd="$1"; local pkg="${2:-$1}"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    printf "%s✓%s %s present\n" "$_c_green" "$_c_reset" "$cmd"; return 0
+  fi
+  ensure_brew
+  spin "Installing $cmd via brew" brew install "$pkg"
+}
+
+update_repo_ff_only() {
+  local dir="$1" name="$2" branch="main"
+  [ -d "$dir/.git" ] || return 1
+  (
+    cd "$dir"
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+      echo "$name has local uncommitted changes; skipping automatic update."
+      return 0
+    fi
+    before="$(git rev-parse HEAD)"
+    git fetch origin "$branch"
+    if git merge-base --is-ancestor HEAD "origin/$branch"; then
+      git merge --ff-only "origin/$branch"
+      after="$(git rev-parse HEAD)"
+      echo "$name $before -> $after"
+    else
+      echo "$name has local commits or divergent history; skipping automatic update."
+    fi
+  )
+}
+
+if ! command -v git >/dev/null 2>&1; then
+  if [ "$OS" = "Darwin" ]; then
+    echo "git is not installed. Install Xcode Command Line Tools now? [Y/n]"
+    read -r ans </dev/tty || ans="Y"
+    if [[ "$ans" =~ ^[Nn] ]]; then echo "Aborted." >&2; exit 1; fi
+    run xcode-select --install || true
+    echo "A dialog opened. Complete the install, then re-run this script."
+    exit 0
+  else
+    ensure_tool git
+  fi
+else
+  printf "%s✓%s git present\n" "$_c_green" "$_c_reset"
+fi
+
+ensure_tool node
+ensure_tool python3 python@3.12
+if [ "$SPOTLIGHT_MODE" = "local" ]; then
+  ensure_brew  # local mode needs brew for the inference server + agent
+fi
+
+if [ "$SPOTLIGHT_VAULT_APP" = "tolaria" ]; then
+  step "Tolaria vault"
+  if [ "$OS" = "Darwin" ]; then
+    if [ -d "/Applications/Tolaria.app" ] || [ -d "$HOME/Applications/Tolaria.app" ]; then
+      printf "%s✓%s Tolaria.app installed\n" "$_c_green" "$_c_reset"
+    else
+      tmpdir="$(mktemp -d)"
+      spin "Downloading Tolaria latest release" curl -L "https://github.com/refactoringhq/tolaria/releases/latest/download/Tolaria.app.tar.gz" -o "$tmpdir/Tolaria.app.tar.gz"
+      run tar -xzf "$tmpdir/Tolaria.app.tar.gz" -C "$tmpdir"
+      app_path="$(find "$tmpdir" -maxdepth 3 -name "Tolaria.app" -type d | head -1)"
+      if [ -z "$app_path" ] && [ "$DRY_RUN" != "1" ]; then echo "Tolaria.app was not found in the release archive." >&2; exit 1; fi
+      run mkdir -p "$HOME/Applications"
+      [ -n "$app_path" ] && run cp -R "$app_path" "$HOME/Applications/Tolaria.app"
+      run rm -rf "$tmpdir"
+      printf "%s✓%s Tolaria.app installed in ~/Applications\n" "$_c_green" "$_c_reset"
+    fi
+    run open -a Tolaria 2>/dev/null || run open "$HOME/Applications/Tolaria.app" 2>/dev/null || true
+  else
+    echo "Tolaria selected. On Linux, install Tolaria from https://tolaria.md/; Spotlight will still write Markdown files to the vault path."
+  fi
+else
+  step "Obsidian vault"
+  if [ -d "/Applications/Obsidian.app" ] || [ -d "$HOME/Applications/Obsidian.app" ]; then
+    printf "%s✓%s Obsidian.app installed\n" "$_c_green" "$_c_reset"
+  else
+    ensure_brew
+    spin "Installing Obsidian via brew cask" brew install --cask obsidian
+  fi
+
+  if ! command -v obsidian >/dev/null 2>&1; then
+    printf "%s!%s Opening Obsidian so you can enable the CLI\n" "$_c_cyan" "$_c_reset"
+    run open -a Obsidian 2>/dev/null || true
+    echo ""
+    echo "  ${_c_bold}Enable the Obsidian CLI (one-time):${_c_reset}"
+    echo "    Settings → General → Advanced → toggle ${_c_bold}Command Line Interface${_c_reset} ON"
+    echo ""
+    echo "  The first time you run ${_c_bold}spotlight${_c_reset}, the preflight check will detect"
+    echo "  whether the CLI is enabled and prompt you again if needed. You can continue"
+    echo "  the rest of this installer now while Obsidian is open."
+    echo ""
+  else
+    printf "%s✓%s obsidian CLI already on PATH\n" "$_c_green" "$_c_reset"
+  fi
+fi
+
+step "Spotlight repo"
+if [ -d "$SPOTLIGHT_DIR/.git" ]; then
+  spin "Updating Spotlight at $SPOTLIGHT_DIR" update_repo_ff_only "$SPOTLIGHT_DIR" "Spotlight"
+else
+  spin "Cloning Spotlight to $SPOTLIGHT_DIR" git clone "$REPO_URL" "$SPOTLIGHT_DIR"
+fi
+cd "$SPOTLIGHT_DIR"
+
+step "Core dependencies"
+if ! command -v firecrawl >/dev/null 2>&1; then
+  spin "Installing firecrawl-cli" npm install -g firecrawl-cli
+else
+  printf "%s✓%s firecrawl-cli already installed\n" "$_c_green" "$_c_reset"
+fi
+
+if ! command -v qmd >/dev/null 2>&1; then
+  spin "Installing QMD vault search" npm install -g @tobilu/qmd
+else
+  printf "%s✓%s qmd already installed\n" "$_c_green" "$_c_reset"
+fi
+
+# =====================================================================
+# LOCAL MODE — inference server + agent harness
+# =====================================================================
+if [ "$SPOTLIGHT_MODE" = "local" ]; then
+
+  # ---- Inference server (llama-server OR Ollama) ----
+  if [ "$SPOTLIGHT_LOCAL_SERVER" = "llamacpp" ]; then
+    step "Local inference (llama-server)"
+    if ! command -v llama-server >/dev/null 2>&1; then
+      spin "Installing llama.cpp via brew" brew install llama.cpp
+    else
+      printf "%s✓%s llama.cpp already installed\n" "$_c_green" "$_c_reset"
+    fi
+    MODEL_DIR="$HOME/Models/$MODEL_LEAF"
+    run mkdir -p "$MODEL_DIR"
+    if [ ! -f "$MODEL_DIR/$GGUF_FILE" ]; then
+      spin "Downloading $GGUF_FILE from huggingface.co/$SPOTLIGHT_MODEL_REPO" \
+        curl -L --fail --retry 3 --continue-at - \
+          "https://huggingface.co/$SPOTLIGHT_MODEL_REPO/resolve/main/$GGUF_FILE" \
+          -o "$MODEL_DIR/$GGUF_FILE"
+    else
+      printf "%s✓%s Model already downloaded at %s\n" "$_c_green" "$_c_reset" "$MODEL_DIR/$GGUF_FILE"
+    fi
+  else
+    step "Local inference (Ollama)"
+    if ! command -v ollama >/dev/null 2>&1; then
+      spin "Installing Ollama via brew" brew install ollama
+      run brew services start ollama 2>/dev/null || true
+      [ "$DRY_RUN" = "1" ] || sleep 2
+    else
+      printf "%s✓%s Ollama already installed\n" "$_c_green" "$_c_reset"
+    fi
+
+    step "Journalism model download ($OLLAMA_SIZE_LABEL)"
+    echo "Ollama will stream download progress below — grab a coffee, 5–15 min on a typical connection."
+    echo ""
+    OLLAMA_MODEL="$OLLAMA_MODEL_DEFAULT"
+    SPOTLIGHT_OLLAMA_ALIAS="$OLLAMA_ALIAS_DEFAULT"
+    if [ "$DRY_RUN" != "1" ] && ! ollama show "$SPOTLIGHT_OLLAMA_ALIAS" >/dev/null 2>&1; then
+      if ! ollama show "$OLLAMA_MODEL" >/dev/null 2>&1; then
+        ollama pull "$OLLAMA_MODEL" || {
+          printf "%s✗%s Ollama could not pull %s.\n" "$_c_red" "$_c_reset" "$OLLAMA_MODEL"
+          printf "   Edit %s/.env after install or re-run with a working OLLAMA_MODEL.\n" "$SPOTLIGHT_DIR"
+          printf "   Example: OLLAMA_MODEL=gemma3:27b SPOTLIGHT_OLLAMA_ALIAS=spotlight-local\n"
+          exit 1
+        }
+      fi
+      TMP_MODELFILE="$(mktemp)"
+      printf "FROM %s\n" "$OLLAMA_MODEL" > "$TMP_MODELFILE"
+      ollama create "$SPOTLIGHT_OLLAMA_ALIAS" -f "$TMP_MODELFILE"
+      rm -f "$TMP_MODELFILE"
+    elif [ "$DRY_RUN" = "1" ]; then
+      printf 'DRY-RUN: ollama pull %s + create alias %s\n' "$OLLAMA_MODEL" "$SPOTLIGHT_OLLAMA_ALIAS"
+    else
+      printf "%s✓%s Ollama alias %s already exists\n" "$_c_green" "$_c_reset" "$SPOTLIGHT_OLLAMA_ALIAS"
+    fi
+  fi
+
+  # ---- Agent harness: opencode OR pi ----
+  if [ "$SPOTLIGHT_AGENT" = "pi" ]; then
+    # Pi has no native sub-agents. Warn before installing.
+    echo ""
+    printf "%s⚠ Pi has no native sub-agents.%s\n" "$_c_red" "$_c_reset"
+    echo "  Spotlight's investigator and fact-checker will share one context,"
+    echo "  weakening the verification independence guarantee."
+    echo "  opencode is the recommended agent for full Spotlight semantics."
+    echo ""
+    if [ "$DRY_RUN" != "1" ]; then
+      echo "  Continue with Pi anyway? [y/N]"
+      read -r ans </dev/tty || ans="N"
+      if [[ ! "$ans" =~ ^[Yy] ]]; then
+        echo "Aborted. Re-run setup.html and pick opencode for the recommended setup."
+        exit 1
+      fi
+    fi
+
+    step "Agent harness (Pi)"
+    if ! command -v pi >/dev/null 2>&1; then
+      spin "Installing @mariozechner/pi-coding-agent via npm" npm install -g @mariozechner/pi-coding-agent
+    else
+      printf "%s✓%s pi already installed\n" "$_c_green" "$_c_reset"
+    fi
+
+    step "pi-llama-cpp extension (model browser for llama-server)"
+    spin "Installing pi-llama-cpp" pi install npm:pi-llama-cpp
+
+    # Symlink Spotlight skills into pi's global skill dir.
+    step "Spotlight skills → pi"
+    run mkdir -p "$HOME/.pi/agent/skills"
+    if [ "$DRY_RUN" = "1" ]; then
+      printf 'DRY-RUN: symlink %s/skills/*/ into ~/.pi/agent/skills/\n' "$SPOTLIGHT_DIR"
+    else
+      for skill_dir in "$SPOTLIGHT_DIR/skills/"*/; do
+        name=$(basename "$skill_dir")
+        ln -sfn "$skill_dir" "$HOME/.pi/agent/skills/$name"
+      done
+      printf "%s✓%s pi loads %s Spotlight skills from ~/.pi/agent/skills/\n" "$_c_green" "$_c_reset" "$(ls -1 "$HOME/.pi/agent/skills" | wc -l | tr -d ' ')"
+    fi
+
+    # Tell pi where the OpenAI-compatible endpoint is.
+    step "Pi inference endpoint config"
+    PI_SETTINGS="$HOME/.pi/agent/settings.json"
+    run mkdir -p "$(dirname "$PI_SETTINGS")"
+    if [ "$DRY_RUN" = "1" ]; then
+      printf 'DRY-RUN: write %s with llamaServerUrl=http://127.0.0.1:%s\n' "$PI_SETTINGS" "$LOCAL_PORT"
+    else
+      if ! command -v jq >/dev/null 2>&1; then spin "Installing jq via brew" brew install jq; fi
+      [ -f "$PI_SETTINGS" ] || echo '{}' > "$PI_SETTINGS"
+      TMP=$(mktemp)
+      jq --arg url "http://127.0.0.1:$LOCAL_PORT" '.llamaServerUrl = $url' "$PI_SETTINGS" > "$TMP" && mv "$TMP" "$PI_SETTINGS"
+      printf "%s✓%s Pi llamaServerUrl set to http://127.0.0.1:%s\n" "$_c_green" "$_c_reset" "$LOCAL_PORT"
+    fi
+
+  else
+    # opencode (default)
+    if [ "$SPOTLIGHT_OPENCODE_INTERFACE" = "desktop" ]; then
+      step "Agent harness (opencode Desktop)"
+      if [ ! -d "/Applications/opencode.app" ] && [ ! -d "$HOME/Applications/opencode.app" ]; then
+        spin "Installing opencode-desktop via brew cask" brew install --cask opencode-desktop
+      else
+        printf "%s✓%s opencode-desktop already installed\n" "$_c_green" "$_c_reset"
+      fi
+      # CLI is needed too for the launcher script and skill registration
+    fi
+    step "Agent harness (opencode CLI)"
+    if ! command -v opencode >/dev/null 2>&1; then
+      spin "Installing opencode via brew" brew install opencode || \
+        bash -c 'curl -fsSL https://opencode.ai/install | bash'
+    else
+      printf "%s✓%s opencode already installed\n" "$_c_green" "$_c_reset"
+    fi
+
+    step "Spotlight skills → opencode"
+    run mkdir -p "$HOME/.config/opencode/skills"
+    if [ "$DRY_RUN" = "1" ]; then
+      printf 'DRY-RUN: symlink %s/skills/*/ into ~/.config/opencode/skills/\n' "$SPOTLIGHT_DIR"
+    else
+      for skill_dir in "$SPOTLIGHT_DIR/skills/"*/; do
+        name=$(basename "$skill_dir")
+        ln -sfn "$skill_dir" "$HOME/.config/opencode/skills/$name"
+      done
+      printf "%s✓%s opencode loads %s Spotlight skills from ~/.config/opencode/skills/\n" "$_c_green" "$_c_reset" "$(ls -1 "$HOME/.config/opencode/skills" | wc -l | tr -d ' ')"
+    fi
+
+    step "opencode provider config"
+    OC_CFG="$HOME/.config/opencode/opencode.json"
+    run mkdir -p "$(dirname "$OC_CFG")"
+    if [ "$DRY_RUN" = "1" ]; then
+      printf 'DRY-RUN: merge %s provider into %s with baseURL=%s\n' "$SPOTLIGHT_LOCAL_SERVER" "$OC_CFG" "$LOCAL_BASE_URL"
+    else
+      [ -f "$OC_CFG" ] || echo '{"$schema":"https://opencode.ai/config.json","provider":{}}' > "$OC_CFG"
+      if ! command -v jq >/dev/null 2>&1; then spin "Installing jq via brew" brew install jq; fi
+      TMP=$(mktemp)
+      if [ "$SPOTLIGHT_LOCAL_SERVER" = "llamacpp" ]; then
+        jq --arg base "$LOCAL_BASE_URL" --arg id "qwen27" --arg name "Qwen3.6-27B Uncensored (local llama.cpp)" \
+          '.provider["llama.cpp"] = {"npm":"@ai-sdk/openai-compatible","name":"llama-server (local)","options":{"baseURL":$base},"models":{($id):{"name":$name}}}' \
+          "$OC_CFG" > "$TMP" && mv "$TMP" "$OC_CFG"
+      else
+        jq --arg base "$LOCAL_BASE_URL" --arg id "$OLLAMA_ALIAS_DEFAULT" --arg name "$MODEL_LEAF (local Ollama)" \
+          '.provider["ollama"] = {"npm":"@ai-sdk/openai-compatible","name":"Ollama (local OpenAI-compatible)","options":{"baseURL":$base},"models":{($id):{"name":$name}}}' \
+          "$OC_CFG" > "$TMP" && mv "$TMP" "$OC_CFG"
+      fi
+      printf "%s✓%s opencode.json updated with %s provider\n" "$_c_green" "$_c_reset" "$SPOTLIGHT_LOCAL_SERVER"
+    fi
+  fi
+
+  # ---- Local launcher script ----
+  step "Spotlight local launcher"
+  run mkdir -p "$HOME/.local/bin"
+  if [ "$DRY_RUN" = "1" ]; then
+    printf 'DRY-RUN: write ~/.local/bin/spotlight-local for %s/%s\n' "$SPOTLIGHT_LOCAL_SERVER" "$SPOTLIGHT_AGENT"
+  else
+    if [ "$SPOTLIGHT_LOCAL_SERVER" = "llamacpp" ]; then
+      if [ "$SPOTLIGHT_AGENT" = "pi" ]; then
+        cat > "$HOME/.local/bin/spotlight-local" <<LAUNCHER_EOF
+#!/usr/bin/env bash
+# Start llama-server + pi for Spotlight investigations.
+set -euo pipefail
+MODEL="\$HOME/Models/$MODEL_LEAF/$GGUF_FILE"
+command -v llama-server >/dev/null 2>&1 || { echo "llama-server missing — brew install llama.cpp" >&2; exit 1; }
+command -v pi           >/dev/null 2>&1 || { echo "pi missing — npm install -g @mariozechner/pi-coding-agent" >&2; exit 1; }
+[ -f "\$MODEL" ] || { echo "Model not found: \$MODEL" >&2; exit 1; }
+lsof -ti:8080 >/dev/null 2>&1 && { echo "Port 8080 already in use — kill the existing process first" >&2; exit 1; }
+llama-server --model "\$MODEL" --alias qwen27 --host 127.0.0.1 --port 8080 \\
+  --ctx-size 65536 --n-gpu-layers 999 --jinja --flash-attn on >/tmp/llama-server-pi.log 2>&1 &
+SERVER_PID=\$!
+cleanup() { kill -TERM "\$SERVER_PID" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM HUP
+echo -n "Waiting for llama-server"
+for i in {1..120}; do curl -sf http://127.0.0.1:8080/v1/models >/dev/null && { echo " ready."; break; }; echo -n "."; sleep 1; done
+pi "\$@"
+LAUNCHER_EOF
+      else
+        cat > "$HOME/.local/bin/spotlight-local" <<LAUNCHER_EOF
+#!/usr/bin/env bash
+# Start llama-server + opencode for Spotlight investigations.
+set -euo pipefail
+MODEL="\$HOME/Models/$MODEL_LEAF/$GGUF_FILE"
+command -v llama-server >/dev/null 2>&1 || { echo "llama-server missing — brew install llama.cpp" >&2; exit 1; }
+command -v opencode     >/dev/null 2>&1 || { echo "opencode missing — brew install opencode" >&2; exit 1; }
+[ -f "\$MODEL" ] || { echo "Model not found: \$MODEL" >&2; exit 1; }
+lsof -ti:8080 >/dev/null 2>&1 && { echo "Port 8080 already in use — kill the existing process first" >&2; exit 1; }
+llama-server --model "\$MODEL" --alias qwen27 --host 127.0.0.1 --port 8080 \\
+  --ctx-size 65536 --n-gpu-layers 999 --jinja --flash-attn on >/tmp/llama-server-opencode.log 2>&1 &
+SERVER_PID=\$!
+cleanup() { kill -TERM "\$SERVER_PID" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM HUP
+echo -n "Waiting for llama-server"
+for i in {1..120}; do curl -sf http://127.0.0.1:8080/v1/models >/dev/null && { echo " ready."; break; }; echo -n "."; sleep 1; done
+opencode --model llama.cpp/qwen27 "\$@"
+LAUNCHER_EOF
+      fi
+    else
+      # Ollama branch
+      if [ "$SPOTLIGHT_AGENT" = "pi" ]; then
+        cat > "$HOME/.local/bin/spotlight-local" <<LAUNCHER_EOF
+#!/usr/bin/env bash
+# Start Ollama + pi for Spotlight investigations.
+set -euo pipefail
+SPOTLIGHT_DIR="\${SPOTLIGHT_DIR:-$SPOTLIGHT_DIR}"
+ENV_FILE="\$SPOTLIGHT_DIR/.env"
+if [ -f "\$ENV_FILE" ]; then set -a; . "\$ENV_FILE"; set +a; fi
+command -v ollama >/dev/null 2>&1 || { echo "ollama missing — brew install ollama" >&2; exit 1; }
+command -v pi     >/dev/null 2>&1 || { echo "pi missing — npm install -g @mariozechner/pi-coding-agent" >&2; exit 1; }
+OLLAMA_MODEL="\${OLLAMA_MODEL:-$OLLAMA_MODEL_DEFAULT}"
+SPOTLIGHT_OLLAMA_ALIAS="\${SPOTLIGHT_OLLAMA_ALIAS:-$OLLAMA_ALIAS_DEFAULT}"
+ollama list >/dev/null 2>&1 || { brew services start ollama 2>/dev/null || ollama serve >/tmp/ollama-spotlight.log 2>&1 & sleep 2; }
+if ! ollama show "\$SPOTLIGHT_OLLAMA_ALIAS" >/dev/null 2>&1; then
+  ollama show "\$OLLAMA_MODEL" >/dev/null 2>&1 || ollama pull "\$OLLAMA_MODEL"
+  TMP_MODELFILE="\$(mktemp)"
+  printf "FROM %s\\n" "\$OLLAMA_MODEL" > "\$TMP_MODELFILE"
+  ollama create "\$SPOTLIGHT_OLLAMA_ALIAS" -f "\$TMP_MODELFILE"
+  rm -f "\$TMP_MODELFILE"
+fi
+pi "\$@"
+LAUNCHER_EOF
+      else
+        cat > "$HOME/.local/bin/spotlight-local" <<LAUNCHER_EOF
+#!/usr/bin/env bash
+# Start Ollama + opencode for Spotlight investigations.
+set -euo pipefail
+expand_path() {
+  local input="\$1"
+  if [ "\$input" = "~" ]; then printf "%s\\n" "\$HOME"
+  elif [[ "\$input" == "~/"* ]]; then printf "%s/%s\\n" "\$HOME" "\${input#~/}"
+  else printf "%s\\n" "\$input"; fi
+}
+SPOTLIGHT_DIR_DEFAULT_INPUT='$SPOTLIGHT_DIR_INPUT'
+SPOTLIGHT_DIR_DEFAULT="\$(expand_path "\$SPOTLIGHT_DIR_DEFAULT_INPUT")"
+SPOTLIGHT_DIR="\${SPOTLIGHT_DIR:-\$SPOTLIGHT_DIR_DEFAULT}"
+ENV_FILE="\$SPOTLIGHT_DIR/.env"
+if [ -f "\$ENV_FILE" ]; then set -a; . "\$ENV_FILE"; set +a; fi
+command -v ollama   >/dev/null 2>&1 || { echo "ollama missing — brew install ollama" >&2; exit 1; }
+command -v opencode >/dev/null 2>&1 || { echo "opencode missing — brew install opencode" >&2; exit 1; }
+OLLAMA_MODEL="\${OLLAMA_MODEL:-$OLLAMA_MODEL_DEFAULT}"
+SPOTLIGHT_OLLAMA_ALIAS="\${SPOTLIGHT_OLLAMA_ALIAS:-$OLLAMA_ALIAS_DEFAULT}"
+ollama list >/dev/null 2>&1 || { brew services start ollama 2>/dev/null || ollama serve >/tmp/ollama-spotlight.log 2>&1 & sleep 2; }
+if ! ollama show "\$SPOTLIGHT_OLLAMA_ALIAS" >/dev/null 2>&1; then
+  if ! ollama show "\$OLLAMA_MODEL" >/dev/null 2>&1; then
+    ollama pull "\$OLLAMA_MODEL" || { echo "Could not pull \$OLLAMA_MODEL. Set OLLAMA_MODEL in \$ENV_FILE to a working Ollama model." >&2; exit 1; }
+  fi
+  TMP_MODELFILE="\$(mktemp)"
+  printf "FROM %s\\n" "\$OLLAMA_MODEL" > "\$TMP_MODELFILE"
+  ollama create "\$SPOTLIGHT_OLLAMA_ALIAS" -f "\$TMP_MODELFILE"
+  rm -f "\$TMP_MODELFILE"
+fi
+opencode --model "ollama/\$SPOTLIGHT_OLLAMA_ALIAS" "\$@"
+LAUNCHER_EOF
+      fi
+    fi
+    chmod +x "$HOME/.local/bin/spotlight-local"
+    printf "%s✓%s Launcher installed at ~/.local/bin/spotlight-local\n" "$_c_green" "$_c_reset"
+  fi
+
+# =====================================================================
+# CLOUD MODE — pick a hosted runtime
+# =====================================================================
+else
+  # SPOTLIGHT_RUNTIME ∈ {claude, gemini, codex, opencode}
+  case "$SPOTLIGHT_RUNTIME" in
+    claude)   RT_BIN=claude;   RT_PKG="@anthropic-ai/claude-code"; RT_CTX="CLAUDE.md";  RT_NAME="Claude Code" ;;
+    gemini)   RT_BIN=gemini;   RT_PKG="@google/gemini-cli";        RT_CTX="GEMINI.md";  RT_NAME="Gemini" ;;
+    codex)    RT_BIN=codex;    RT_PKG="@openai/codex";             RT_CTX="";           RT_NAME="Codex" ;;
+    opencode) RT_BIN=opencode; RT_PKG="opencode-ai";               RT_CTX="";           RT_NAME="OpenCode" ;;
+    *) echo "Unknown SPOTLIGHT_RUNTIME: $SPOTLIGHT_RUNTIME" >&2; exit 1 ;;
+  esac
+
+  RT_LABEL="$RT_NAME"
+  [ "$SPOTLIGHT_RUNTIME" = "opencode" ] && [ -n "$SPOTLIGHT_OPENCODE_PROVIDER" ] && \
+    RT_LABEL="OpenCode (provider: $SPOTLIGHT_OPENCODE_PROVIDER)"
+
+  step "$RT_LABEL"
+  if ! command -v "$RT_BIN" >/dev/null 2>&1; then
+    if [ "$SPOTLIGHT_RUNTIME" = "gemini" ]; then
+      NPM_PREFIX="$HOME/.npm-global"; run mkdir -p "$NPM_PREFIX"
+      spin "Installing $RT_PKG" npm install -g --prefix "$NPM_PREFIX" "$RT_PKG"
+      export PATH="$NPM_PREFIX/bin:$PATH"
+    else
+      spin "Installing $RT_PKG" npm install -g "$RT_PKG"
+    fi
+  else
+    printf "%s✓%s %s already installed\n" "$_c_green" "$_c_reset" "$RT_BIN"
+  fi
+  if [ -n "$RT_CTX" ]; then
+    run ln -sfn "$SPOTLIGHT_DIR/AGENTS.md" "$SPOTLIGHT_DIR/$RT_CTX"
+    printf "%s✓%s AGENTS.md linked as %s\n" "$_c_green" "$_c_reset" "$RT_CTX"
+  fi
+  if [ "$SPOTLIGHT_RUNTIME" = "opencode" ]; then
+    printf "%s✓%s Provider key will be loaded from .env (%s)\n" "$_c_green" "$_c_reset" "$SPOTLIGHT_CLOUD_KEY_VAR"
+    run mkdir -p "$HOME/.config/opencode/skills"
+    if [ "$DRY_RUN" = "1" ]; then
+      printf 'DRY-RUN: symlink %s/skills/*/ into ~/.config/opencode/skills/\n' "$SPOTLIGHT_DIR"
+    else
+      for skill_dir in "$SPOTLIGHT_DIR/skills/"*/; do
+        name=$(basename "$skill_dir")
+        ln -sfn "$skill_dir" "$HOME/.config/opencode/skills/$name"
+      done
+      printf "%s✓%s opencode loads Spotlight skills from %s/.config/opencode/skills/\n" "$_c_green" "$_c_reset" "$HOME"
+    fi
+  fi
+fi
+
+step "Python dependencies"
+spin "Installing jsonschema + requests" bash -c "pip3 install --user --quiet jsonschema requests 2>/dev/null || pip install --user --quiet jsonschema requests"
+if [ "$SPOTLIGHT_INT_BROWSERUSE" = "true" ]; then
+  spin "Installing browser-use" bash -c "pip3 install --user --quiet browser-use 2>/dev/null || pip install --user --quiet browser-use"
+  spin "Installing Chromium for browser-use" bash -c "python3 -m playwright install chromium 2>/dev/null || true"
+fi
+
+# === Write .env ===
+echo "→ Writing $SPOTLIGHT_DIR/.env (chmod 600)"
+write_env_var() {
+  local name="$1" value="$2"
+  printf "%s=%q\n" "$name" "$value" >> "$SPOTLIGHT_DIR/.env"
+}
+if [ "$DRY_RUN" = "1" ]; then
+  printf 'DRY-RUN: write .env with FIRECRAWL_API_KEY, OSINT_NAV_API_KEY, %s + integration keys\n' "${SPOTLIGHT_CLOUD_KEY_VAR:-<none>}"
+else
+  cat > "$SPOTLIGHT_DIR/.env" <<'ENV_HEADER'
+# Spotlight environment — generated by install-spotlight.sh
+ENV_HEADER
+  write_env_var SPOTLIGHT_DIR "$SPOTLIGHT_DIR"
+  write_env_var SPOTLIGHT_VAULT_PATH "$SPOTLIGHT_VAULT_PATH"
+  write_env_var SPOTLIGHT_CASES_ROOT "$SPOTLIGHT_CASES_ROOT"
+  write_env_var FIRECRAWL_API_KEY "$FIRECRAWL_API_KEY"
+  write_env_var OSINT_NAV_API_KEY "$OSINT_NAV_API_KEY"
+  if [ -n "$SPOTLIGHT_CLOUD_KEY_VAR" ] && [ -n "$SPOTLIGHT_CLOUD_KEY" ]; then
+    write_env_var "$SPOTLIGHT_CLOUD_KEY_VAR" "$SPOTLIGHT_CLOUD_KEY"
+  fi
+  if [ "$SPOTLIGHT_INT_JUNKIPEDIA" = "true" ] && [ -n "$JUNKIPEDIA_API_KEY" ]; then
+    write_env_var JUNKIPEDIA_API_KEY "$JUNKIPEDIA_API_KEY"
+  fi
+  if [ "$SPOTLIGHT_INT_UNPAYWALL" = "true" ] && [ -n "$UNPAYWALL_EMAIL" ]; then
+    write_env_var UNPAYWALL_EMAIL "$UNPAYWALL_EMAIL"
+  fi
+  if [ "$SPOTLIGHT_MODE" = "local" ]; then
+    write_env_var MODEL_REPO "$SPOTLIGHT_MODEL_REPO"
+    write_env_var LOCAL_SERVER "$SPOTLIGHT_LOCAL_SERVER"
+    write_env_var LOCAL_ENDPOINT "$LOCAL_BASE_URL"
+    write_env_var SPOTLIGHT_AGENT "$SPOTLIGHT_AGENT"
+    if [ "$SPOTLIGHT_LOCAL_SERVER" = "ollama" ]; then
+      write_env_var OLLAMA_MODEL "$OLLAMA_MODEL_DEFAULT"
+      write_env_var SPOTLIGHT_OLLAMA_ALIAS "$OLLAMA_ALIAS_DEFAULT"
+    fi
+  fi
+  chmod 600 "$SPOTLIGHT_DIR/.env"
+fi
+
+step "Writing .spotlight-config.json"
+if [ "$DRY_RUN" = "1" ]; then
+  printf 'DRY-RUN: write %s/.spotlight-config.json\n' "$SPOTLIGHT_DIR"
+else
+  cat > "$SPOTLIGHT_DIR/.spotlight-config.json" <<CONFIG_EOF
+{
+  "search_library": "firecrawl",
+  "vault_path": "$SPOTLIGHT_VAULT_PATH",
+  "vault_type": "$([ "$SPOTLIGHT_VAULT_APP" = "tolaria" ] && echo tolaria || echo obsidian)",
+  "vault_app": "$SPOTLIGHT_VAULT_APP",
+  "cases_root": "$SPOTLIGHT_CASES_ROOT",
+  "install_path": "$SPOTLIGHT_DIR",
+  "mode": "$SPOTLIGHT_MODE",
+  "runtime": "$SPOTLIGHT_RUNTIME",
+  "local_server": $([ -n "$SPOTLIGHT_LOCAL_SERVER" ] && printf '"%s"' "$SPOTLIGHT_LOCAL_SERVER" || echo null),
+  "agent": $([ "$SPOTLIGHT_MODE" = "local" ] && printf '"%s"' "$SPOTLIGHT_AGENT" || echo null),
+  "opencode_provider": $([ -n "$SPOTLIGHT_OPENCODE_PROVIDER" ] && printf '"%s"' "$SPOTLIGHT_OPENCODE_PROVIDER" || echo null),
+  "integrations": {
+    "osint_navigator": true,
+    "junkipedia": $SPOTLIGHT_INT_JUNKIPEDIA,
+    "browser_use": $SPOTLIGHT_INT_BROWSERUSE,
+    "unpaywall": $SPOTLIGHT_INT_UNPAYWALL
+  },
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "last_used": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+CONFIG_EOF
+fi
+
+step "Vault scaffold"
+run mkdir -p "$SPOTLIGHT_CASES_ROOT" "$SPOTLIGHT_VAULT_PATH/evidence" "$SPOTLIGHT_VAULT_PATH/captures" "$SPOTLIGHT_VAULT_PATH/briefs" "$SPOTLIGHT_VAULT_PATH/exports" "$SPOTLIGHT_VAULT_PATH/handoff-to-mycroft" "$SPOTLIGHT_VAULT_PATH/_schema"
+if [ "$DRY_RUN" != "1" ] && [ ! -f "$SPOTLIGHT_VAULT_PATH/_index.md" ]; then
+  cat > "$SPOTLIGHT_VAULT_PATH/_index.md" <<'INDEX_EOF'
+---
+type: spotlight-index
+tags: [spotlight, index]
+---
+# Spotlight Vault
+
+- cases/ — active investigations
+- evidence/ — verified source material and citations
+- captures/ — local page/document captures
+- briefs/ — case summaries and handoffs
+- exports/ — publishable packets and review artifacts
+- handoff-to-mycroft/ — durable findings promoted to Mycroft
+INDEX_EOF
+fi
+if [ "$DRY_RUN" != "1" ] && [ ! -f "$SPOTLIGHT_CASES_ROOT/_template.md" ]; then
+  cat > "$SPOTLIGHT_CASES_ROOT/_template.md" <<'CASE_TEMPLATE_EOF'
+---
+type: spotlight-case
+status: draft
+tags: [spotlight, investigation]
+---
+# Case Template
+
+## Lead
+
+## Evidence
+
+## Open Questions
+CASE_TEMPLATE_EOF
+fi
+if [ "$DRY_RUN" != "1" ] && command -v qmd >/dev/null 2>&1; then
+  qmd collection add "$SPOTLIGHT_VAULT_PATH" --name spotlight >/dev/null 2>&1 || true
+  qmd update >/dev/null 2>&1 || true
+  printf "%s✓%s QMD spotlight collection configured\n" "$_c_green" "$_c_reset"
+fi
+if [ "$SPOTLIGHT_VAULT_APP" = "obsidian" ] && [ "$OS" = "Darwin" ]; then
+  run open -a Obsidian "$SPOTLIGHT_VAULT_PATH" 2>/dev/null || true
+fi
+
+step "Spotlight command wrappers"
+run mkdir -p "$HOME/.local/bin" "$SPOTLIGHT_DIR/.spotlight/logs"
+if [ "$DRY_RUN" = "1" ]; then
+  printf 'DRY-RUN: write spotlight-doctor and spotlight-update to ~/.local/bin\n'
+else
+  cat > "$HOME/.local/bin/spotlight-doctor" <<DOCTOR_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="\$HOME/.local/bin:\$HOME/.npm-global/bin:\$PATH"
+expand_path() {
+  local input="\$1"
+  if [ "\$input" = "~" ]; then printf "%s\\n" "\$HOME"
+  elif [[ "\$input" == "~/"* ]]; then printf "%s/%s\\n" "\$HOME" "\${input#~/}"
+  else printf "%s\\n" "\$input"; fi
+}
+SPOTLIGHT_DIR_DEFAULT_INPUT='$SPOTLIGHT_DIR_INPUT'
+SPOTLIGHT_VAULT_INPUT='$SPOTLIGHT_VAULT_INPUT'
+SPOTLIGHT_DIR_DEFAULT="\$(expand_path "\$SPOTLIGHT_DIR_DEFAULT_INPUT")"
+SPOTLIGHT_DIR="\${SPOTLIGHT_DIR:-\$SPOTLIGHT_DIR_DEFAULT}"
+SPOTLIGHT_VAULT_PATH="\${SPOTLIGHT_VAULT_PATH:-\$(expand_path "\$SPOTLIGHT_VAULT_INPUT")}"
+SPOTLIGHT_CASES_ROOT="\${SPOTLIGHT_CASES_ROOT:-\$SPOTLIGHT_VAULT_PATH/cases}"
+fail=0
+ok() { printf "OK    %s\\n" "\$1"; }
+bad() { printf "FAIL  %s\\n" "\$1"; fail=1; }
+check_path() { [ -e "\$1" ] && ok "\$2" || bad "\$2 missing: \$1"; }
+check_cmd() { command -v "\$1" >/dev/null 2>&1 && ok "\$2" || bad "\$2 missing"; }
+check_env_name() { grep -q "^\$1=" "\$SPOTLIGHT_DIR/.env" 2>/dev/null && ok "\$1 configured" || bad "\$1 missing from .env"; }
+check_path "\$SPOTLIGHT_DIR/.git" "Spotlight repo"
+check_path "\$SPOTLIGHT_DIR/AGENTS.md" "AGENTS runtime contract"
+check_path "\$SPOTLIGHT_DIR/.spotlight-config.json" "Spotlight config"
+check_path "\$SPOTLIGHT_DIR/.env" "Spotlight env"
+check_env_name FIRECRAWL_API_KEY
+check_env_name OSINT_NAV_API_KEY
+check_path "\$SPOTLIGHT_VAULT_PATH" "Spotlight vault"
+check_path "\$SPOTLIGHT_CASES_ROOT" "Spotlight cases root"
+check_cmd firecrawl "Firecrawl CLI"
+check_cmd qmd "QMD CLI"
+DOCTOR_EOF
+  # Append runtime-specific checks
+  case "$SPOTLIGHT_RUNTIME" in
+    local)
+      if [ "$SPOTLIGHT_AGENT" = "pi" ]; then
+        echo 'check_cmd pi "pi (local agent)"' >> "$HOME/.local/bin/spotlight-doctor"
+      else
+        echo 'check_cmd opencode "opencode (local agent)"' >> "$HOME/.local/bin/spotlight-doctor"
+      fi
+      echo 'check_cmd spotlight-local "Spotlight local launcher"' >> "$HOME/.local/bin/spotlight-doctor"
+      ;;
+    claude)   echo 'check_cmd claude "Claude Code"' >> "$HOME/.local/bin/spotlight-doctor"; echo 'check_path "$SPOTLIGHT_DIR/CLAUDE.md" "Claude context link"' >> "$HOME/.local/bin/spotlight-doctor" ;;
+    gemini)   echo 'check_cmd gemini "Gemini"' >> "$HOME/.local/bin/spotlight-doctor"; echo 'check_path "$SPOTLIGHT_DIR/GEMINI.md" "Gemini context link"' >> "$HOME/.local/bin/spotlight-doctor" ;;
+    codex)    echo 'check_cmd codex "Codex"' >> "$HOME/.local/bin/spotlight-doctor" ;;
+    opencode) echo 'check_cmd opencode "OpenCode"' >> "$HOME/.local/bin/spotlight-doctor" ;;
+  esac
+  [ -n "$SPOTLIGHT_CLOUD_KEY_VAR" ] && echo "check_env_name $SPOTLIGHT_CLOUD_KEY_VAR" >> "$HOME/.local/bin/spotlight-doctor"
+  [ "$SPOTLIGHT_INT_JUNKIPEDIA" = "true" ] && echo 'check_env_name JUNKIPEDIA_API_KEY' >> "$HOME/.local/bin/spotlight-doctor"
+  [ "$SPOTLIGHT_INT_UNPAYWALL" = "true" ] && echo 'check_env_name UNPAYWALL_EMAIL' >> "$HOME/.local/bin/spotlight-doctor"
+  cat >> "$HOME/.local/bin/spotlight-doctor" <<'DOCTOR_TAIL'
+if [ -x "$SPOTLIGHT_DIR/tests/smoke.sh" ]; then (cd "$SPOTLIGHT_DIR" && bash tests/smoke.sh >/dev/null) && ok "Smoke test" || bad "Smoke test failed"; fi
+if [ -x "$SPOTLIGHT_DIR/integrations/preflight.py" ] || [ -f "$SPOTLIGHT_DIR/integrations/preflight.py" ]; then (cd "$SPOTLIGHT_DIR" && set -a && . .env && set +a && python3 integrations/preflight.py --text >/dev/null) && ok "Integration preflight" || bad "Integration preflight reported issues"; fi
+if [ "$fail" -eq 0 ]; then printf "\nSpotlight doctor: OK\n"; else printf "\nSpotlight doctor: failed\n"; fi
+exit "$fail"
+DOCTOR_TAIL
+  chmod +x "$HOME/.local/bin/spotlight-doctor"
+
+  cat > "$HOME/.local/bin/spotlight-update" <<UPDATE_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+expand_path() {
+  local input="\$1"
+  if [ "\$input" = "~" ]; then printf "%s\\n" "\$HOME"
+  elif [[ "\$input" == "~/"* ]]; then printf "%s/%s\\n" "\$HOME" "\${input#~/}"
+  else printf "%s\\n" "\$input"; fi
+}
+SPOTLIGHT_DIR_DEFAULT_INPUT='$SPOTLIGHT_DIR_INPUT'
+SPOTLIGHT_DIR_DEFAULT="\$(expand_path "\$SPOTLIGHT_DIR_DEFAULT_INPUT")"
+SPOTLIGHT_DIR="\${SPOTLIGHT_DIR:-\$SPOTLIGHT_DIR_DEFAULT}"
+log_dir="\$SPOTLIGHT_DIR/.spotlight/logs"
+mkdir -p "\$log_dir"
+log="\$log_dir/update.log"
+exec >>"\$log" 2>&1
+echo ""
+date
+[ -d "\$SPOTLIGHT_DIR/.git" ] || { echo "Spotlight repo missing: \$SPOTLIGHT_DIR"; exit 1; }
+cd "\$SPOTLIGHT_DIR"
+if ! git diff --quiet || ! git diff --cached --quiet; then echo "Spotlight has local uncommitted changes; skipping update."; exit 0; fi
+before="\$(git rev-parse HEAD)"
+git fetch origin main
+if git merge-base --is-ancestor HEAD origin/main; then
+  git merge --ff-only origin/main
+  after="\$(git rev-parse HEAD)"
+  echo "Spotlight \$before -> \$after"
+else
+  echo "Spotlight has local commits or divergent history; skipping update."
+  exit 0
+fi
+if "\$HOME/.local/bin/spotlight-doctor"; then
+  echo "doctor passed"
+else
+  echo "doctor failed after update; rolling back to \$before"
+  git reset --hard "\$before"
+  exit 1
+fi
+echo "update complete"
+UPDATE_EOF
+  chmod +x "$HOME/.local/bin/spotlight-update"
+  printf "%s✓%s spotlight doctor/update wrappers installed\n" "$_c_green" "$_c_reset"
+fi
+
+# === Install spotlight shell command ===
+SHELL_RC=""
+case "$SHELL" in
+  */zsh) SHELL_RC="$HOME/.zshrc" ;;
+  */bash) SHELL_RC="$HOME/.bashrc" ;;
+  *) SHELL_RC="$HOME/.profile" ;;
+esac
+
+if [ "$DRY_RUN" = "1" ]; then
+  printf 'DRY-RUN: write spotlight() function to %s\n' "$SHELL_RC"
+else
+  touch "$SHELL_RC"
+  tmp_rc="$(mktemp)"
+  awk '
+    /^# SPOTLIGHT-BEGIN/ { skip=1; next }
+    /^# SPOTLIGHT-END/ { skip=0; next }
+    !skip { print }
+  ' "$SHELL_RC" > "$tmp_rc"
+  mv "$tmp_rc" "$SHELL_RC"
+  echo "→ Writing \"spotlight\" command to $SHELL_RC"
+
+  # Pick the bin to launch based on runtime + agent
+  case "$SPOTLIGHT_RUNTIME" in
+    local)
+      LAUNCH_BIN="spotlight-local"
+      ;;
+    claude)   LAUNCH_BIN="claude" ;;
+    gemini)   LAUNCH_BIN="gemini" ;;
+    codex)    LAUNCH_BIN="codex" ;;
+    opencode) LAUNCH_BIN="opencode" ;;
+  esac
+
+  {
+    echo ""
+    echo "# SPOTLIGHT-BEGIN — added by install-spotlight.sh"
+    printf "export SPOTLIGHT_DIR=%q\n" "$SPOTLIGHT_DIR"
+    cat <<SHELL_EOF
+export PATH="\$HOME/.local/bin:\$HOME/.npm-global/bin:\$PATH"
+spotlight() {
+  local dir="\${SPOTLIGHT_DIR:-\$HOME/spotlight}"
+  if [ ! -d "\$dir" ]; then
+    echo "Spotlight not installed at \$dir. Re-run the installer." >&2
+    return 1
+  fi
+  case "\${1:-}" in
+    update)
+      SPOTLIGHT_DIR="\$dir" "\$HOME/.local/bin/spotlight-update"
+      ;;
+    doctor)
+      SPOTLIGHT_DIR="\$dir" "\$HOME/.local/bin/spotlight-doctor"
+      ;;
+    --help|-h|help)
+      cat <<HELP
+Usage: spotlight [subcommand]
+
+  (no arg)   Launch the configured runtime and start investigating
+  update     Fetch origin/main, fast-forward only, then run doctor
+  doctor     Run the smoke test (checks structure, schemas, preflights)
+  help       This message
+HELP
+      return 0
+      ;;
+  esac
+  (cd "\$dir" && { [ -f .env ] && set -a && source .env && set +a; } && $LAUNCH_BIN)
+}
+# SPOTLIGHT-END
+SHELL_EOF
+  } >> "$SHELL_RC"
+fi
+
+step "Preflight"
+if [ "$DRY_RUN" = "1" ]; then
+  printf 'DRY-RUN: source .env + run python3 integrations/preflight.py --text\n'
+else
+  set -a; source "$SPOTLIGHT_DIR/.env"; set +a
+  python3 "$SPOTLIGHT_DIR/integrations/preflight.py" --text || true
+fi
+
+echo ""
+echo "${_c_green}${_c_bold}  ╔════════════════════════════════════════════════╗${_c_reset}"
+echo "${_c_green}${_c_bold}  ║   ✓  Spotlight installed                       ║${_c_reset}"
+echo "${_c_green}${_c_bold}  ╚════════════════════════════════════════════════╝${_c_reset}"
+echo ""
+echo "  Open a new terminal window and type:"
+echo ""
+echo "    ${_c_bold}spotlight${_c_reset}"
+echo ""
+echo "  Then tell the agent: ${_c_dim}Start a Spotlight investigation on <your lead>${_c_reset}"
+echo ""
+echo "  Docs: $SPOTLIGHT_DIR/docs/README.md"
+echo ""

--- a/setup.html
+++ b/setup.html
@@ -1059,23 +1059,37 @@
           <h2 data-reveal="title">Hosted on your Mac.</h2>
         </div>
         <section class="card">
-          <label class="block">Local server</label>
+          <label class="block">Inference server</label>
           <div class="radio-group" id="local-server-group">
             <label><input type="radio" name="local_server" value="llamacpp" checked><span class="opt-name"><span class="name">llama-server</span><span class="desc">Lean and Terminal-only. The script installs it via <code>brew install llama.cpp</code>, downloads the model GGUF from Hugging Face, and serves on <code>127.0.0.1:8080</code>.</span></span></label>
             <label><input type="radio" name="local_server" value="ollama"><span class="opt-name"><span class="name">Ollama</span><span class="desc">CLI-first model manager. The script installs it via <code>brew</code>, pulls the model, starts the service — nothing to click.</span></span></label>
           </div>
 
+          <label class="block" style="margin-top: 24px;">Agent harness</label>
+          <div class="radio-group" id="agent-group">
+            <label><input type="radio" name="agent" value="opencode" checked><span class="opt-name"><span class="name">opencode</span><span class="desc">Recommended. Native sub-agents — investigator and fact-checker run in independent contexts, preserving Spotlight's verification independence guarantee.</span></span></label>
+            <label><input type="radio" name="agent" value="pi"><span class="opt-name"><span class="name">Pi</span><span class="desc">Minimal TypeScript harness (<a href="https://pi.dev" target="_blank">pi.dev</a>) with the <code>pi-llama-cpp</code> extension for model browsing. <strong>No native sub-agents</strong> — investigator and fact-checker share one context, weakening independence. Choose this only for a lean install.</span></span></label>
+          </div>
+
+          <div id="opencode-interface-wrap">
           <label class="block" style="margin-top: 24px;">opencode interface</label>
           <div class="radio-group" id="opencode-interface-group">
             <label><input type="radio" name="opencode_interface" value="cli" checked><span class="opt-name"><span class="name">CLI (Terminal)</span><span class="desc">Lighter — installs <code>brew install opencode</code> and runs in your Terminal. Recommended.</span></span></label>
             <label><input type="radio" name="opencode_interface" value="desktop"><span class="opt-name"><span class="name">Desktop GUI</span><span class="desc">Installs <code>brew install --cask opencode-desktop</code> — same agent, point-and-click app.</span></span></label>
           </div>
+          </div>
 
-          <p class="lede" id="local-lede-llamacpp" style="margin-top: 16px;">
+          <p class="lede" id="local-lede-llamacpp-opencode" style="margin-top: 16px;">
             The installer uses <strong>opencode</strong> (<a href="https://opencode.ai" target="_blank">opencode.ai</a>, MIT) as the agent harness with <strong>llama-server</strong> (llama.cpp) serving the model locally on <code>127.0.0.1:8080</code>. opencode reads Spotlight's skills + AGENTS.md natively; native sub-agents handle the investigator/fact-checker pattern.
           </p>
-          <p class="lede hidden" id="local-lede-ollama" style="margin-top: 16px;">
+          <p class="lede hidden" id="local-lede-ollama-opencode" style="margin-top: 16px;">
             The installer uses <strong>opencode</strong> (<a href="https://opencode.ai" target="_blank">opencode.ai</a>, MIT) as the agent harness and <strong>Ollama</strong> to serve the model locally on <code>127.0.0.1:11434</code>. Both install with one command.
+          </p>
+          <p class="lede hidden" id="local-lede-llamacpp-pi" style="margin-top: 16px;">
+            The installer uses <strong>Pi</strong> (<a href="https://pi.dev" target="_blank">pi.dev</a>, MIT) as the agent harness with <strong>llama-server</strong> serving the model on <code>127.0.0.1:8080</code>. The <code>pi-llama-cpp</code> extension lets you browse/load/switch models from inside Pi. Note: Pi has no native sub-agents, so investigator + fact-checker share context.
+          </p>
+          <p class="lede hidden" id="local-lede-ollama-pi" style="margin-top: 16px;">
+            The installer uses <strong>Pi</strong> (<a href="https://pi.dev" target="_blank">pi.dev</a>, MIT) as the agent harness with <strong>Ollama</strong> on <code>127.0.0.1:11434</code>. Pi's <code>pi-llama-cpp</code> extension speaks the same OpenAI-compatible API surface. Note: Pi has no native sub-agents.
           </p>
 
           <div class="fit-row">
@@ -1519,15 +1533,23 @@
   }
   document.querySelectorAll('input[name="local_model"]').forEach(el => el.addEventListener('change', renderLocalModel));
 
-  // --- Local server switching (llama-server vs Ollama) ---
+  // --- Local server + agent switching ---
   function renderLocalServer() {
     const srv = document.querySelector('input[name="local_server"]:checked').value;
-    document.getElementById('local-lede-llamacpp').classList.toggle('hidden', srv !== 'llamacpp');
-    document.getElementById('local-lede-ollama').classList.toggle('hidden', srv !== 'ollama');
+    const agentEl = document.querySelector('input[name="agent"]:checked');
+    const agent = agentEl ? agentEl.value : 'opencode';
+    // Toggle the four lede variants — only the matching (server, agent) pair is shown.
+    ['llamacpp-opencode', 'ollama-opencode', 'llamacpp-pi', 'ollama-pi'].forEach(key => {
+      const want = `${srv}-${agent}`;
+      document.getElementById('local-lede-' + key).classList.toggle('hidden', key !== want);
+    });
     document.getElementById('local-note-llamacpp').classList.toggle('hidden', srv !== 'llamacpp');
     document.getElementById('local-note-ollama').classList.toggle('hidden', srv !== 'ollama');
+    // opencode-interface picker is opencode-only.
+    document.getElementById('opencode-interface-wrap').classList.toggle('hidden', agent !== 'opencode');
   }
   document.querySelectorAll('input[name="local_server"]').forEach(el => el.addEventListener('change', renderLocalServer));
+  document.querySelectorAll('input[name="agent"]').forEach(el => el.addEventListener('change', renderLocalServer));
 
   // --- Runtime registry (single source of truth) ---
   // Subscription runtimes (claude/gemini/codex) authenticate via their CLI's OAuth login —
@@ -1629,6 +1651,7 @@
       runtime: mode === 'local' ? 'local' : cloudRt,
       local_model: mode === 'local' ? document.querySelector('input[name="local_model"]:checked').value : null,
       local_server: mode === 'local' ? document.querySelector('input[name="local_server"]:checked').value : null,
+      agent: mode === 'local' ? document.querySelector('input[name="agent"]:checked').value : null,
       opencode_interface: mode === 'local' ? document.querySelector('input[name="opencode_interface"]:checked').value : null,
       opencode_provider: cloudRt === 'opencode' ? opencodeProv : null,
       cloud_key: mode === 'cloud' ? document.getElementById('cloud_key').value.trim() : '',
@@ -1652,709 +1675,56 @@
     return "'" + String(s).replace(/'/g, "'\\''") + "'";
   }
 
-  function buildScript(cfg) {
-    const lines = [];
-    const p = s => lines.push(s);
+  function buildExportBlock(cfg) {
+    // Built as: export KEY='value'  (single-quote escaped via shellEscape).
+    // install-spotlight.sh decodes this base64 + evals it.
+    const fields = [
+      ['SPOTLIGHT_MODE',                cfg.mode || ''],
+      ['SPOTLIGHT_RUNTIME',             cfg.runtime || ''],
+      ['SPOTLIGHT_LOCAL_SERVER',        cfg.local_server || ''],
+      ['SPOTLIGHT_LOCAL_MODEL',         cfg.local_model || ''],
+      ['SPOTLIGHT_AGENT',               cfg.agent || ''],
+      ['SPOTLIGHT_OPENCODE_INTERFACE',  cfg.opencode_interface || 'cli'],
+      ['SPOTLIGHT_OPENCODE_PROVIDER',   cfg.opencode_provider || ''],
+      ['SPOTLIGHT_CLOUD_KEY_VAR',       cfg.cloud_key_var || ''],
+      ['SPOTLIGHT_CLOUD_KEY',           cfg.cloud_key || ''],
+      ['SPOTLIGHT_DIR_INPUT',           cfg.install_path || ''],
+      ['SPOTLIGHT_VAULT_INPUT',         cfg.vault_path || ''],
+      ['SPOTLIGHT_VAULT_APP',           cfg.vault_app || 'obsidian'],
+      ['SPOTLIGHT_MODEL_REPO',          cfg.model_repo || ''],
+      ['SPOTLIGHT_INT_BROWSERUSE',      cfg.int_browseruse ? 'true' : 'false'],
+      ['SPOTLIGHT_INT_JUNKIPEDIA',      cfg.int_junkipedia ? 'true' : 'false'],
+      ['JUNKIPEDIA_API_KEY',            cfg.junkipedia_key || ''],
+      ['SPOTLIGHT_INT_UNPAYWALL',       cfg.int_unpaywall ? 'true' : 'false'],
+      ['UNPAYWALL_EMAIL',               cfg.unpaywall_email || ''],
+      ['FIRECRAWL_API_KEY',             cfg.firecrawl_key || ''],
+      ['OSINT_NAV_API_KEY',             cfg.nav_key || ''],
+    ];
+    return fields.map(([k, v]) => `export ${k}=${shellEscape(String(v))}`).join('\n');
+  }
 
-    p('#!/usr/bin/env bash');
-    p('# Spotlight installer — generated ' + new Date().toISOString());
-    p('# Mode: ' + cfg.mode + (cfg.mode === 'cloud' ? ' (' + cfg.runtime + (cfg.opencode_provider ? '/' + cfg.opencode_provider : '') + ')' : ''));
-    p('set -euo pipefail');
-    p('');
-    p('expand_path() {');
-    p('  local input="$1"');
-    p('  if [ "$input" = "~" ]; then printf "%s\\n" "$HOME";');
-    p('  elif [[ "$input" == "~/"* ]]; then printf "%s/%s\\n" "$HOME" "${input#~/}";');
-    p('  else printf "%s\\n" "$input"; fi');
-    p('}');
-    p('');
-    p('SPOTLIGHT_DIR_INPUT=' + shellEscape(cfg.install_path));
-    p('if [ -n "${SPOTLIGHT_DIR:-}" ]; then');
-    p('  SPOTLIGHT_DIR="$SPOTLIGHT_DIR"');
-    p('else');
-    p('  SPOTLIGHT_DIR="$(expand_path "$SPOTLIGHT_DIR_INPUT")"');
-    p('fi');
-    p('SPOTLIGHT_VAULT_INPUT=' + shellEscape(cfg.vault_path));
-    p('SPOTLIGHT_VAULT_PATH="$(expand_path "$SPOTLIGHT_VAULT_INPUT")"');
-    p('SPOTLIGHT_CASES_ROOT="$SPOTLIGHT_VAULT_PATH/cases"');
-    p('REPO_URL="https://github.com/buriedsignals/spotlight.git"');
-    p('export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"');
-    p('');
-    p('_c_reset=$\'\\033[0m\'; _c_cyan=$\'\\033[36m\'; _c_green=$\'\\033[32m\'; _c_red=$\'\\033[31m\'; _c_dim=$\'\\033[2m\'; _c_bold=$\'\\033[1m\'');
-    p('_spin_frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)');
-    p('');
-    p('spin() {');
-    p('  local msg="$1"; shift');
-    p('  local tmpfile; tmpfile="$(mktemp)"');
-    p('  ( "$@" ) >"$tmpfile" 2>&1 &');
-    p('  local pid=$!');
-    p('  local i=0 n=${#_spin_frames[@]}');
-    p('  printf "\\033[?25l" 2>/dev/null || true');
-    p('  while kill -0 $pid 2>/dev/null; do');
-    p('    printf "\\r\\033[K%s%s%s %s" "$_c_cyan" "${_spin_frames[$((i % n))]}" "$_c_reset" "$msg"');
-    p('    i=$((i + 1))');
-    p('    sleep 0.08');
-    p('  done');
-    p('  wait $pid 2>/dev/null; local status=$?');
-    p('  printf "\\033[?25h" 2>/dev/null || true');
-    p('  if [ $status -eq 0 ]; then');
-    p('    printf "\\r\\033[K%s✓%s %s\\n" "$_c_green" "$_c_reset" "$msg"');
-    p('  else');
-    p('    printf "\\r\\033[K%s✗%s %s\\n" "$_c_red" "$_c_reset" "$msg"');
-    p('    echo "$_c_dim─── output ───$_c_reset"');
-    p('    cat "$tmpfile"');
-    p('  fi');
-    p('  rm -f "$tmpfile"');
-    p('  return $status');
-    p('}');
-    p('');
-    p('step() { printf "\\n%s%s━━ %s ━━%s\\n" "$_c_bold" "$_c_cyan" "$1" "$_c_reset"; }');
-    p('');
-    p('echo ""');
-    p('echo "${_c_bold}${_c_cyan}  ╔════════════════════════════════════════════════╗${_c_reset}"');
-    p('echo "${_c_bold}${_c_cyan}  ║           Spotlight installer                  ║${_c_reset}"');
-    p('echo "${_c_bold}${_c_cyan}  ╚════════════════════════════════════════════════╝${_c_reset}"');
-    p('echo ""');
-    p('');
-    p('OS="$(uname -s)"');
-    p('if [ "$OS" != "Darwin" ] && [ "$OS" != "Linux" ]; then');
-    p('  echo "Unsupported OS: $OS. macOS or Linux required (Windows: use WSL)." >&2');
-    p('  exit 1');
-    p('fi');
-    p('');
-    p('step "Prerequisites"');
-    p('');
-    p('ensure_brew() {');
-    p('  if command -v brew >/dev/null 2>&1; then');
-    p('    printf "%s✓%s Homebrew present\\n" "$_c_green" "$_c_reset"; return 0');
-    p('  fi');
-    p('  echo ""');
-    p('  echo "Homebrew is needed to install other tools. Install it now? [Y/n]"');
-    p('  read -r ans || ans="Y"');
-    p('  if [[ "$ans" =~ ^[Nn] ]]; then echo "Aborted." >&2; exit 1; fi');
-    p('  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"');
-    p('  [ -x /opt/homebrew/bin/brew ] && eval "$(/opt/homebrew/bin/brew shellenv)"');
-    p('  [ -x /usr/local/bin/brew ] && eval "$(/usr/local/bin/brew shellenv)"');
-    p('}');
-    p('');
-    p('ensure_tool() {');
-    p('  local cmd="$1"; local pkg="${2:-$1}"');
-    p('  if command -v "$cmd" >/dev/null 2>&1; then');
-    p('    printf "%s✓%s %s present\\n" "$_c_green" "$_c_reset" "$cmd"; return 0');
-    p('  fi');
-    p('  ensure_brew');
-    p('  spin "Installing $cmd via brew" brew install "$pkg"');
-    p('}');
-    p('');
-    p('update_repo_ff_only() {');
-    p('  local dir="$1" name="$2" branch="main"');
-    p('  [ -d "$dir/.git" ] || return 1');
-    p('  (');
-    p('    cd "$dir"');
-    p('    if ! git diff --quiet || ! git diff --cached --quiet; then');
-    p('      echo "$name has local uncommitted changes; skipping automatic update."');
-    p('      return 0');
-    p('    fi');
-    p('    before="$(git rev-parse HEAD)"');
-    p('    git fetch origin "$branch"');
-    p('    if git merge-base --is-ancestor HEAD "origin/$branch"; then');
-    p('      git merge --ff-only "origin/$branch"');
-    p('      after="$(git rev-parse HEAD)"');
-    p('      echo "$name $before -> $after"');
-    p('    else');
-    p('      echo "$name has local commits or divergent history; skipping automatic update."');
-    p('    fi');
-    p('  )');
-    p('}');
-    p('');
-    p('if ! command -v git >/dev/null 2>&1; then');
-    p('  if [ "$OS" = "Darwin" ]; then');
-    p('    echo "git is not installed. Install Xcode Command Line Tools now? [Y/n]"');
-    p('    read -r ans || ans="Y"');
-    p('    if [[ "$ans" =~ ^[Nn] ]]; then echo "Aborted." >&2; exit 1; fi');
-    p('    xcode-select --install || true');
-    p('    echo "A dialog opened. Complete the install, then re-run this script."');
-    p('    exit 0');
-    p('  else');
-    p('    ensure_tool git');
-    p('  fi');
-    p('else');
-    p('  printf "%s✓%s git present\\n" "$_c_green" "$_c_reset"');
-    p('fi');
-    p('');
-    p('ensure_tool node');
-    p('ensure_tool python3 python@3.12');
-    if (cfg.mode === 'local') {
-      p('ensure_brew  # local mode needs brew for ' + (cfg.local_server === 'llamacpp' ? 'llama.cpp' : 'ollama') + ' + opencode');
-    }
-    p('');
-    if (cfg.vault_app === 'tolaria') {
-      p('step "Tolaria vault"');
-      p('if [ "$OS" = "Darwin" ]; then');
-      p('  if [ -d "/Applications/Tolaria.app" ] || [ -d "$HOME/Applications/Tolaria.app" ]; then');
-      p('    printf "%s✓%s Tolaria.app installed\\n" "$_c_green" "$_c_reset"');
-      p('  else');
-      p('    tmpdir="$(mktemp -d)"');
-      p('    spin "Downloading Tolaria latest release" curl -L "https://github.com/refactoringhq/tolaria/releases/latest/download/Tolaria.app.tar.gz" -o "$tmpdir/Tolaria.app.tar.gz"');
-      p('    tar -xzf "$tmpdir/Tolaria.app.tar.gz" -C "$tmpdir"');
-      p('    app_path="$(find "$tmpdir" -maxdepth 3 -name "Tolaria.app" -type d | head -1)"');
-      p('    if [ -z "$app_path" ]; then echo "Tolaria.app was not found in the release archive." >&2; exit 1; fi');
-      p('    mkdir -p "$HOME/Applications"');
-      p('    cp -R "$app_path" "$HOME/Applications/Tolaria.app"');
-      p('    rm -rf "$tmpdir"');
-      p('    printf "%s✓%s Tolaria.app installed in ~/Applications\\n" "$_c_green" "$_c_reset"');
-      p('  fi');
-      p('  open -a Tolaria 2>/dev/null || open "$HOME/Applications/Tolaria.app" 2>/dev/null || true');
-      p('else');
-      p('  echo "Tolaria selected. On Linux, install Tolaria from https://tolaria.md/; Spotlight will still write Markdown files to the vault path."');
-      p('fi');
-    } else {
-      p('step "Obsidian vault"');
-      p('if [ -d "/Applications/Obsidian.app" ] || [ -d "$HOME/Applications/Obsidian.app" ]; then');
-      p('  printf "%s✓%s Obsidian.app installed\\n" "$_c_green" "$_c_reset"');
-      p('else');
-      p('  ensure_brew');
-      p('  spin "Installing Obsidian via brew cask" brew install --cask obsidian');
-      p('fi');
-      p('');
-      p('if ! command -v obsidian >/dev/null 2>&1; then');
-      p('  printf "%s!%s Opening Obsidian so you can enable the CLI\\n" "$_c_cyan" "$_c_reset"');
-      p('  open -a Obsidian 2>/dev/null || true');
-      p('  echo ""');
-      p('  echo "  ${_c_bold}Enable the Obsidian CLI (one-time):${_c_reset}"');
-      p('  echo "    Settings → General → Advanced → toggle ${_c_bold}Command Line Interface${_c_reset} ON"');
-      p('  echo ""');
-      p('  echo "  The first time you run ${_c_bold}spotlight${_c_reset}, the preflight check will detect"');
-      p('  echo "  whether the CLI is enabled and prompt you again if needed. You can continue"');
-      p('  echo "  the rest of this installer now while Obsidian is open."');
-      p('  echo ""');
-      p('else');
-      p('  printf "%s✓%s obsidian CLI already on PATH\\n" "$_c_green" "$_c_reset"');
-      p('fi');
-    }
-    p('');
-    p('step "Spotlight repo"');
-    p('if [ -d "$SPOTLIGHT_DIR/.git" ]; then');
-    p('  spin "Updating Spotlight at $SPOTLIGHT_DIR" update_repo_ff_only "$SPOTLIGHT_DIR" "Spotlight"');
-    p('else');
-    p('  spin "Cloning Spotlight to $SPOTLIGHT_DIR" git clone "$REPO_URL" "$SPOTLIGHT_DIR"');
-    p('fi');
-    p('cd "$SPOTLIGHT_DIR"');
-    p('');
-    p('step "Core dependencies"');
-    p('if ! command -v firecrawl >/dev/null 2>&1; then');
-    p('  spin "Installing firecrawl-cli" npm install -g firecrawl-cli');
-    p('else');
-    p('  printf "%s✓%s firecrawl-cli already installed\\n" "$_c_green" "$_c_reset"');
-    p('fi');
-    p('');
-    p('if ! command -v qmd >/dev/null 2>&1; then');
-    p('  spin "Installing QMD vault search" npm install -g @tobilu/qmd');
-    p('else');
-    p('  printf "%s✓%s qmd already installed\\n" "$_c_green" "$_c_reset"');
-    p('fi');
-    p('');
+  function utf8Base64(str) {
+    // TextEncoder + manual byte-string → btoa avoids the deprecated unescape() pattern.
+    const bytes = new TextEncoder().encode(str);
+    let bin = '';
+    for (const b of bytes) bin += String.fromCharCode(b);
+    return btoa(bin);
+  }
 
-    if (cfg.mode === 'local') {
-      // Pick a default GGUF filename per model — Q4_K_M (best size/quality tradeoff for journalists)
-      const modelLeaf = cfg.model_repo.split('/').slice(-1)[0];
-      const isGemma = cfg.model_repo.indexOf('gemma-4') >= 0;
-      const ggufFile = isGemma
-        ? 'gemma-4-26B-A4B-it-UD-Q4_K_M.gguf'
-        : 'Qwen3.6-27B-Uncensored-HauhauCS-Aggressive-Q4_K_P.gguf';
-      const ollamaModel = isGemma
-        ? 'hf.co/unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M'
-        : 'hf.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive:IQ2_M';
-      const ollamaAlias = isGemma ? 'spotlight-gemma4-q4' : 'spotlight-qwen36-27b-q4';
-      const port = cfg.local_server === 'llamacpp' ? '8080' : '11434';
-      const baseURL = 'http://127.0.0.1:' + port + '/v1';
+  const INSTALLER_URL = 'https://raw.githubusercontent.com/buriedsignals/spotlight/main/install-spotlight.sh';
 
-      if (cfg.local_server === 'llamacpp') {
-        p('step "Local inference (llama-server + opencode)"');
-        p('if ! command -v llama-server >/dev/null 2>&1; then');
-        p('  spin "Installing llama.cpp via brew" brew install llama.cpp');
-        p('else');
-        p('  printf "%s✓%s llama.cpp already installed\\n" "$_c_green" "$_c_reset"');
-        p('fi');
-        p('');
-        p('MODEL_DIR="$HOME/Models/' + modelLeaf + '"');
-        p('mkdir -p "$MODEL_DIR"');
-        p('GGUF_FILE="' + ggufFile + '"');
-        p('if [ ! -f "$MODEL_DIR/$GGUF_FILE" ]; then');
-        p('  spin "Downloading $GGUF_FILE from huggingface.co/' + cfg.model_repo + '" \\');
-        p('    curl -L --fail --retry 3 --continue-at - "https://huggingface.co/' + cfg.model_repo + '/resolve/main/$GGUF_FILE" -o "$MODEL_DIR/$GGUF_FILE"');
-        p('else');
-        p('  printf "%s✓%s Model already downloaded at $MODEL_DIR/$GGUF_FILE\\n" "$_c_green" "$_c_reset"');
-        p('fi');
-        p('');
-      } else {
-        p('step "Local inference (Ollama + opencode)"');
-        p('if ! command -v ollama >/dev/null 2>&1; then');
-        p('  spin "Installing Ollama via brew" brew install ollama');
-        p('  brew services start ollama 2>/dev/null || true');
-        p('  sleep 2');
-        p('else');
-        p('  printf "%s✓%s Ollama already installed\\n" "$_c_green" "$_c_reset"');
-        p('fi');
-        p('');
-        var ollamaSize = isGemma ? '~8 GB' : '~10 GB';
-        p('step "Journalism model download (' + ollamaSize + ')"');
-        p('echo "Ollama will stream download progress below — grab a coffee, 5–15 min on a typical connection."');
-        p('echo ""');
-        p('OLLAMA_MODEL=' + shellEscape(ollamaModel));
-        p('SPOTLIGHT_OLLAMA_ALIAS=' + shellEscape(ollamaAlias));
-        p('if ! ollama show "$SPOTLIGHT_OLLAMA_ALIAS" >/dev/null 2>&1; then');
-        p('  if ! ollama show "$OLLAMA_MODEL" >/dev/null 2>&1; then');
-        p('    ollama pull "$OLLAMA_MODEL" || {');
-        p('      printf "%s✗%s Ollama could not pull $OLLAMA_MODEL.\\n" "$_c_red" "$_c_reset"');
-        p('      printf "   Edit $SPOTLIGHT_DIR/.env after install or re-run with a working OLLAMA_MODEL.\\n"');
-        p('      printf "   Example: OLLAMA_MODEL=gemma3:27b SPOTLIGHT_OLLAMA_ALIAS=spotlight-local\\n"');
-        p('      exit 1');
-        p('    }');
-        p('  fi');
-        p('  TMP_MODELFILE="$(mktemp)"');
-        p('  printf "FROM %s\\n" "$OLLAMA_MODEL" > "$TMP_MODELFILE"');
-        p('  ollama create "$SPOTLIGHT_OLLAMA_ALIAS" -f "$TMP_MODELFILE"');
-        p('  rm -f "$TMP_MODELFILE"');
-        p('else');
-        p('  printf "%s✓%s Ollama alias $SPOTLIGHT_OLLAMA_ALIAS already exists\\n" "$_c_green" "$_c_reset"');
-        p('fi');
-        p('');
-      }
+  function buildOneLiner(cfg) {
+    const block = buildExportBlock(cfg);
+    const b64 = utf8Base64(block);
+    return `curl -fsSL ${INSTALLER_URL} | SPOTLIGHT_CONFIG='${b64}' bash`;
+  }
 
-      // Install opencode (CLI or Desktop based on user choice)
-      if (cfg.opencode_interface === 'desktop') {
-        p('step "Agent harness (opencode Desktop)"');
-        p('if [ ! -d "/Applications/opencode.app" ] && [ ! -d "$HOME/Applications/opencode.app" ]; then');
-        p('  spin "Installing opencode-desktop via brew cask" brew install --cask opencode-desktop');
-        p('else');
-        p('  printf "%s✓%s opencode-desktop already installed\\n" "$_c_green" "$_c_reset"');
-        p('fi');
-        p('');
-        p('# CLI is needed too for the launcher script and skill registration');
-      }
-      p('step "Agent harness (opencode CLI)"');
-      p('if ! command -v opencode >/dev/null 2>&1; then');
-      p('  spin "Installing opencode via brew" brew install opencode || \\');
-      p('    bash -c \'curl -fsSL https://opencode.ai/install | bash\'');
-      p('else');
-      p('  printf "%s✓%s opencode already installed\\n" "$_c_green" "$_c_reset"');
-      p('fi');
-      p('');
-
-      // Symlink Spotlight skills into opencode's global skill dir (one per sub-skill — opencode is one-level glob)
-      p('step "Spotlight skills → opencode"');
-      p('mkdir -p "$HOME/.config/opencode/skills"');
-      p('for skill_dir in "$SPOTLIGHT_DIR/skills/"*/; do');
-      p('  name=$(basename "$skill_dir")');
-      p('  ln -sfn "$skill_dir" "$HOME/.config/opencode/skills/$name"');
-      p('done');
-      p('printf "%s✓%s opencode loads $(ls -1 $HOME/.config/opencode/skills | wc -l | tr -d \" \") Spotlight skills from $HOME/.config/opencode/skills/\\n" "$_c_green" "$_c_reset"');
-      p('');
-
-      // Merge llama.cpp / ollama provider into opencode.json via jq (preserves any existing providers)
-      p('step "opencode provider config"');
-      p('OC_CFG="$HOME/.config/opencode/opencode.json"');
-      p('mkdir -p "$(dirname "$OC_CFG")"');
-      p('[ -f "$OC_CFG" ] || echo \'{"$schema":"https://opencode.ai/config.json","provider":{}}\' > "$OC_CFG"');
-      p('if ! command -v jq >/dev/null 2>&1; then spin "Installing jq via brew" brew install jq; fi');
-      p('TMP=$(mktemp)');
-      if (cfg.local_server === 'llamacpp') {
-        p('jq --arg base "' + baseURL + '" --arg id "qwen27" --arg name "Qwen3.6-27B Uncensored (local llama.cpp)" \\');
-        p('  \'.provider["llama.cpp"] = {"npm":"@ai-sdk/openai-compatible","name":"llama-server (local)","options":{"baseURL":$base},"models":{($id):{"name":$name}}}\' \\');
-        p('  "$OC_CFG" > "$TMP" && mv "$TMP" "$OC_CFG"');
-      } else {
-        p('jq --arg base "' + baseURL + '" --arg id "' + ollamaAlias + '" --arg name "' + modelLeaf + ' (local Ollama)" \\');
-        p('  \'.provider["ollama"] = {"npm":"@ai-sdk/openai-compatible","name":"Ollama (local OpenAI-compatible)","options":{"baseURL":$base},"models":{($id):{"name":$name}}}\' \\');
-        p('  "$OC_CFG" > "$TMP" && mv "$TMP" "$OC_CFG"');
-      }
-      p('printf "%s✓%s opencode.json updated with ' + (cfg.local_server === 'llamacpp' ? 'llama.cpp' : 'ollama') + ' provider\\n" "$_c_green" "$_c_reset"');
-      p('');
-
-      // Write a launcher script that starts the inference server, then opencode
-      if (cfg.local_server === 'llamacpp') {
-        p('step "Spotlight local launcher"');
-        p('mkdir -p "$HOME/.local/bin"');
-        p('cat > "$HOME/.local/bin/spotlight-local" <<\'LAUNCHER_EOF\'');
-        p('#!/usr/bin/env bash');
-        p('# Start llama-server + opencode for Spotlight investigations.');
-        p('set -euo pipefail');
-        p('MODEL="$HOME/Models/' + modelLeaf + '/' + ggufFile + '"');
-        p('command -v llama-server >/dev/null 2>&1 || { echo "llama-server missing — brew install llama.cpp" >&2; exit 1; }');
-        p('command -v opencode    >/dev/null 2>&1 || { echo "opencode missing — brew install opencode" >&2; exit 1; }');
-        p('[ -f "$MODEL" ] || { echo "Model not found: $MODEL" >&2; exit 1; }');
-        p('lsof -ti:8080 >/dev/null 2>&1 && { echo "Port 8080 already in use — kill the existing process first" >&2; exit 1; }');
-        p('llama-server --model "$MODEL" --alias qwen27 --host 127.0.0.1 --port 8080 \\');
-        p('  --ctx-size 65536 --n-gpu-layers 999 --jinja --flash-attn on >/tmp/llama-server-opencode.log 2>&1 &');
-        p('SERVER_PID=$!');
-        p('cleanup() { kill -TERM "$SERVER_PID" 2>/dev/null || true; }');
-        p('trap cleanup EXIT INT TERM HUP');
-        p('echo -n "Waiting for llama-server"');
-        p('for i in {1..120}; do curl -sf http://127.0.0.1:8080/v1/models >/dev/null && { echo " ready."; break; }; echo -n "."; sleep 1; done');
-        p('opencode --model llama.cpp/qwen27 "$@"');
-        p('LAUNCHER_EOF');
-        p('chmod +x "$HOME/.local/bin/spotlight-local"');
-        p('printf "%s✓%s Launcher installed at ~/.local/bin/spotlight-local — add ~/.local/bin to PATH and run \\`spotlight-local\\`\\n" "$_c_green" "$_c_reset"');
-        p('');
-      } else {
-        p('step "Spotlight local launcher"');
-        p('mkdir -p "$HOME/.local/bin"');
-        p('cat > "$HOME/.local/bin/spotlight-local" <<\'LAUNCHER_EOF\'');
-        p('#!/usr/bin/env bash');
-        p('# Start Ollama + opencode for Spotlight investigations.');
-        p('set -euo pipefail');
-        p('expand_path() {');
-        p('  local input="$1"');
-        p('  if [ "$input" = "~" ]; then printf "%s\\n" "$HOME";');
-        p('  elif [[ "$input" == "~/"* ]]; then printf "%s/%s\\n" "$HOME" "${input#~/}";');
-        p('  else printf "%s\\n" "$input"; fi');
-        p('}');
-        p('SPOTLIGHT_DIR_DEFAULT_INPUT=' + shellEscape(cfg.install_path));
-        p('SPOTLIGHT_DIR_DEFAULT="$(expand_path "$SPOTLIGHT_DIR_DEFAULT_INPUT")"');
-        p('SPOTLIGHT_DIR="${SPOTLIGHT_DIR:-$SPOTLIGHT_DIR_DEFAULT}"');
-        p('ENV_FILE="$SPOTLIGHT_DIR/.env"');
-        p('if [ -f "$ENV_FILE" ]; then set -a; . "$ENV_FILE"; set +a; fi');
-        p('command -v ollama   >/dev/null 2>&1 || { echo "ollama missing — brew install ollama" >&2; exit 1; }');
-        p('command -v opencode >/dev/null 2>&1 || { echo "opencode missing — brew install opencode" >&2; exit 1; }');
-        p('OLLAMA_MODEL="${OLLAMA_MODEL:-' + ollamaModel + '}"');
-        p('SPOTLIGHT_OLLAMA_ALIAS="${SPOTLIGHT_OLLAMA_ALIAS:-' + ollamaAlias + '}"');
-        p('ollama list >/dev/null 2>&1 || { brew services start ollama 2>/dev/null || ollama serve >/tmp/ollama-spotlight.log 2>&1 & sleep 2; }');
-        p('if ! ollama show "$SPOTLIGHT_OLLAMA_ALIAS" >/dev/null 2>&1; then');
-        p('  if ! ollama show "$OLLAMA_MODEL" >/dev/null 2>&1; then');
-        p('    ollama pull "$OLLAMA_MODEL" || { echo "Could not pull $OLLAMA_MODEL. Set OLLAMA_MODEL in $ENV_FILE to a working Ollama model." >&2; exit 1; }');
-        p('  fi');
-        p('  TMP_MODELFILE="$(mktemp)"');
-        p('  printf "FROM %s\\n" "$OLLAMA_MODEL" > "$TMP_MODELFILE"');
-        p('  ollama create "$SPOTLIGHT_OLLAMA_ALIAS" -f "$TMP_MODELFILE"');
-        p('  rm -f "$TMP_MODELFILE"');
-        p('fi');
-        p('opencode --model "ollama/$SPOTLIGHT_OLLAMA_ALIAS" "$@"');
-        p('LAUNCHER_EOF');
-        p('chmod +x "$HOME/.local/bin/spotlight-local"');
-        p('printf "%s✓%s Launcher installed at ~/.local/bin/spotlight-local — add ~/.local/bin to PATH and run \\`spotlight-local\\`\\n" "$_c_green" "$_c_reset"');
-        p('');
-      }
-    } else {
-      const r = RUNTIMES[cfg.runtime];
-      const label = cfg.runtime === 'opencode'
-        ? 'OpenCode (provider: ' + cfg.opencode_provider + ')'
-        : 'Runtime: ' + r.name;
-      p('step "' + label + '"');
-      p('if ! command -v ' + r.bin + ' >/dev/null 2>&1; then');
-      if (cfg.runtime === 'gemini') {
-        p('  NPM_PREFIX="$HOME/.npm-global"; mkdir -p "$NPM_PREFIX"');
-        p('  spin "Installing ' + r.installPkg + '" npm install -g --prefix "$NPM_PREFIX" ' + r.installPkg);
-        p('  export PATH="$NPM_PREFIX/bin:$PATH"');
-      } else {
-        p('  spin "Installing ' + r.installPkg + '" npm install -g ' + r.installPkg);
-      }
-      p('else');
-      p('  printf "%s✓%s ' + r.bin + ' already installed\\n" "$_c_green" "$_c_reset"');
-      p('fi');
-      if (r.contextFile) {
-        p('ln -sfn "$SPOTLIGHT_DIR/AGENTS.md" "$SPOTLIGHT_DIR/' + r.contextFile + '"');
-        p('printf "%s✓%s AGENTS.md linked as ' + r.contextFile + '\\n" "$_c_green" "$_c_reset"');
-      }
-      if (cfg.runtime === 'opencode') {
-        p('printf "%s✓%s Provider key will be loaded from .env (' + cfg.cloud_key_var + ')\\n" "$_c_green" "$_c_reset"');
-        p('mkdir -p "$HOME/.config/opencode/skills"');
-        p('for skill_dir in "$SPOTLIGHT_DIR/skills/"*/; do');
-        p('  name=$(basename "$skill_dir")');
-        p('  ln -sfn "$skill_dir" "$HOME/.config/opencode/skills/$name"');
-        p('done');
-        p('printf "%s✓%s opencode loads Spotlight skills from $HOME/.config/opencode/skills/\\n" "$_c_green" "$_c_reset"');
-      }
-    }
-    p('');
-
-    p('step "Python dependencies"');
-    p('spin "Installing jsonschema + requests" bash -c "pip3 install --user --quiet jsonschema requests 2>/dev/null || pip install --user --quiet jsonschema requests"');
-    if (cfg.int_browseruse) {
-      p('spin "Installing browser-use" bash -c "pip3 install --user --quiet browser-use 2>/dev/null || pip install --user --quiet browser-use"');
-      p('spin "Installing Chromium for browser-use" bash -c "python3 -m playwright install chromium 2>/dev/null || true"');
-    }
-    p('');
-
-    p('# ── Write .env ──');
-    p('echo "→ Writing $SPOTLIGHT_DIR/.env (chmod 600)"');
-    p('write_env_var() {');
-    p('  local name="$1" value="$2"');
-    p('  printf "%s=%q\\n" "$name" "$value" >> "$SPOTLIGHT_DIR/.env"');
-    p('}');
-    p('cat > "$SPOTLIGHT_DIR/.env" <<\'ENV_HEADER\'');
-    p('# Spotlight environment — generated by setup.html');
-    p('ENV_HEADER');
-    p('write_env_var SPOTLIGHT_DIR "$SPOTLIGHT_DIR"');
-    p('write_env_var SPOTLIGHT_VAULT_PATH "$SPOTLIGHT_VAULT_PATH"');
-    p('write_env_var SPOTLIGHT_CASES_ROOT "$SPOTLIGHT_CASES_ROOT"');
-    p('write_env_var FIRECRAWL_API_KEY ' + shellEscape(cfg.firecrawl_key));
-    p('write_env_var OSINT_NAV_API_KEY ' + shellEscape(cfg.nav_key));
-    if (cfg.cloud_key && cfg.cloud_key_var) {
-      p('write_env_var ' + cfg.cloud_key_var + ' ' + shellEscape(cfg.cloud_key));
-    }
-    if (cfg.int_junkipedia && cfg.junkipedia_key) {
-      p('write_env_var JUNKIPEDIA_API_KEY ' + shellEscape(cfg.junkipedia_key));
-    }
-    if (cfg.int_unpaywall && cfg.unpaywall_email) {
-      p('write_env_var UNPAYWALL_EMAIL ' + shellEscape(cfg.unpaywall_email));
-    }
-    if (cfg.mode === 'local') {
-      p('write_env_var MODEL_REPO ' + shellEscape(cfg.model_repo));
-      p('write_env_var LOCAL_SERVER ' + shellEscape(cfg.local_server || 'llamacpp'));
-      p('write_env_var LOCAL_ENDPOINT ' + shellEscape(cfg.local_server === 'llamacpp' ? 'http://127.0.0.1:8080/v1' : 'http://127.0.0.1:11434/v1'));
-      if (cfg.local_server === 'ollama') {
-        const isGemmaEnv = cfg.model_repo.indexOf('gemma-4') >= 0;
-        const ollamaModelEnv = isGemmaEnv
-          ? 'hf.co/unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M'
-          : 'hf.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive:IQ2_M';
-        const ollamaAliasEnv = isGemmaEnv ? 'spotlight-gemma4-q4' : 'spotlight-qwen36-27b-q4';
-        p('write_env_var OLLAMA_MODEL ' + shellEscape(ollamaModelEnv));
-        p('write_env_var SPOTLIGHT_OLLAMA_ALIAS ' + shellEscape(ollamaAliasEnv));
-      }
-    }
-    p('chmod 600 "$SPOTLIGHT_DIR/.env"');
-    p('');
-
-    p('step "Writing .spotlight-config.json"');
-    p('cat > "$SPOTLIGHT_DIR/.spotlight-config.json" <<CONFIG_EOF');
-    p('{');
-    p('  "search_library": "firecrawl",');
-    p('  "vault_path": "$SPOTLIGHT_VAULT_PATH",');
-    p('  "vault_type": "' + (cfg.vault_app === 'tolaria' ? 'tolaria' : 'obsidian') + '",');
-    p('  "vault_app": "' + cfg.vault_app + '",');
-    p('  "cases_root": "$SPOTLIGHT_CASES_ROOT",');
-    p('  "install_path": "$SPOTLIGHT_DIR",');
-    p('  "mode": "' + cfg.mode + '",');
-    p('  "runtime": "' + cfg.runtime + '",');
-    p('  "local_server": ' + (cfg.local_server ? JSON.stringify(cfg.local_server) : 'null') + ',');
-    p('  "opencode_provider": ' + (cfg.opencode_provider ? JSON.stringify(cfg.opencode_provider) : 'null') + ',');
-    p('  "integrations": {');
-    p('    "osint_navigator": true,');
-    p('    "junkipedia": ' + (cfg.int_junkipedia ? 'true' : 'false') + ',');
-    p('    "browser_use": ' + (cfg.int_browseruse ? 'true' : 'false') + ',');
-    p('    "unpaywall": ' + (cfg.int_unpaywall ? 'true' : 'false'));
-    p('  },');
-    p('  "created_at": "' + new Date().toISOString() + '",');
-    p('  "last_used": "' + new Date().toISOString() + '"');
-    p('}');
-    p('CONFIG_EOF');
-    p('');
-    p('step "Vault scaffold"');
-    p('mkdir -p "$SPOTLIGHT_CASES_ROOT" "$SPOTLIGHT_VAULT_PATH/evidence" "$SPOTLIGHT_VAULT_PATH/captures" "$SPOTLIGHT_VAULT_PATH/briefs" "$SPOTLIGHT_VAULT_PATH/exports" "$SPOTLIGHT_VAULT_PATH/handoff-to-mycroft" "$SPOTLIGHT_VAULT_PATH/_schema"');
-    p('if [ ! -f "$SPOTLIGHT_VAULT_PATH/_index.md" ]; then');
-    p('  cat > "$SPOTLIGHT_VAULT_PATH/_index.md" <<\'INDEX_EOF\'');
-    p('---');
-    p('type: spotlight-index');
-    p('tags: [spotlight, index]');
-    p('---');
-    p('# Spotlight Vault');
-    p('');
-    p('- cases/ — active investigations');
-    p('- evidence/ — verified source material and citations');
-    p('- captures/ — local page/document captures');
-    p('- briefs/ — case summaries and handoffs');
-    p('- exports/ — publishable packets and review artifacts');
-    p('- handoff-to-mycroft/ — durable findings promoted to Mycroft');
-    p('INDEX_EOF');
-    p('fi');
-    p('if [ ! -f "$SPOTLIGHT_CASES_ROOT/_template.md" ]; then');
-    p('  cat > "$SPOTLIGHT_CASES_ROOT/_template.md" <<\'CASE_TEMPLATE_EOF\'');
-    p('---');
-    p('type: spotlight-case');
-    p('status: draft');
-    p('tags: [spotlight, investigation]');
-    p('---');
-    p('# Case Template');
-    p('');
-    p('## Lead');
-    p('');
-    p('## Evidence');
-    p('');
-    p('## Open Questions');
-    p('CASE_TEMPLATE_EOF');
-    p('fi');
-    p('if command -v qmd >/dev/null 2>&1; then');
-    p('  qmd collection add "$SPOTLIGHT_VAULT_PATH" --name spotlight >/dev/null 2>&1 || true');
-    p('  qmd update >/dev/null 2>&1 || true');
-    p('  printf "%s✓%s QMD spotlight collection configured\\n" "$_c_green" "$_c_reset"');
-    p('fi');
-    if (cfg.vault_app === 'obsidian') {
-      p('if [ "$OS" = "Darwin" ]; then open -a Obsidian "$SPOTLIGHT_VAULT_PATH" 2>/dev/null || true; fi');
-    }
-    p('');
-
-    p('step "Spotlight command wrappers"');
-    p('mkdir -p "$HOME/.local/bin" "$SPOTLIGHT_DIR/.spotlight/logs"');
-    p('cat > "$HOME/.local/bin/spotlight-doctor" <<\'DOCTOR_EOF\'');
-    p('#!/usr/bin/env bash');
-    p('set -euo pipefail');
-    p('export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"');
-    p('expand_path() {');
-    p('  local input="$1"');
-    p('  if [ "$input" = "~" ]; then printf "%s\\n" "$HOME";');
-    p('  elif [[ "$input" == "~/"* ]]; then printf "%s/%s\\n" "$HOME" "${input#~/}";');
-    p('  else printf "%s\\n" "$input"; fi');
-    p('}');
-    p('SPOTLIGHT_DIR_DEFAULT_INPUT=' + shellEscape(cfg.install_path));
-    p('SPOTLIGHT_VAULT_INPUT=' + shellEscape(cfg.vault_path));
-    p('SPOTLIGHT_DIR_DEFAULT="$(expand_path "$SPOTLIGHT_DIR_DEFAULT_INPUT")"');
-    p('SPOTLIGHT_DIR="${SPOTLIGHT_DIR:-$SPOTLIGHT_DIR_DEFAULT}"');
-    p('SPOTLIGHT_VAULT_PATH="${SPOTLIGHT_VAULT_PATH:-$(expand_path "$SPOTLIGHT_VAULT_INPUT")}"');
-    p('SPOTLIGHT_CASES_ROOT="${SPOTLIGHT_CASES_ROOT:-$SPOTLIGHT_VAULT_PATH/cases}"');
-    p('fail=0');
-    p('ok() { printf "OK    %s\\n" "$1"; }');
-    p('bad() { printf "FAIL  %s\\n" "$1"; fail=1; }');
-    p('check_path() { [ -e "$1" ] && ok "$2" || bad "$2 missing: $1"; }');
-    p('check_cmd() { command -v "$1" >/dev/null 2>&1 && ok "$2" || bad "$2 missing"; }');
-    p('check_env_name() { grep -q "^$1=" "$SPOTLIGHT_DIR/.env" 2>/dev/null && ok "$1 configured" || bad "$1 missing from .env"; }');
-    p('check_path "$SPOTLIGHT_DIR/.git" "Spotlight repo"');
-    p('check_path "$SPOTLIGHT_DIR/AGENTS.md" "AGENTS runtime contract"');
-    p('check_path "$SPOTLIGHT_DIR/.spotlight-config.json" "Spotlight config"');
-    p('check_path "$SPOTLIGHT_DIR/.env" "Spotlight env"');
-    p('check_env_name FIRECRAWL_API_KEY');
-    p('check_env_name OSINT_NAV_API_KEY');
-    p('check_path "$SPOTLIGHT_VAULT_PATH" "Spotlight vault"');
-    p('check_path "$SPOTLIGHT_CASES_ROOT" "Spotlight cases root"');
-    p('check_cmd firecrawl "Firecrawl CLI"');
-    p('check_cmd qmd "QMD CLI"');
-    p('check_cmd ' + RUNTIMES[cfg.runtime].bin + ' "' + RUNTIMES[cfg.runtime].name + '"');
-    if (cfg.runtime === 'claude') p('check_path "$SPOTLIGHT_DIR/CLAUDE.md" "Claude context link"');
-    if (cfg.runtime === 'gemini') p('check_path "$SPOTLIGHT_DIR/GEMINI.md" "Gemini context link"');
-    if (cfg.cloud_key_var) p('check_env_name ' + cfg.cloud_key_var);
-    if (cfg.int_junkipedia) p('check_env_name JUNKIPEDIA_API_KEY');
-    if (cfg.int_unpaywall) p('check_env_name UNPAYWALL_EMAIL');
-    p('if [ -x "$SPOTLIGHT_DIR/tests/smoke.sh" ]; then (cd "$SPOTLIGHT_DIR" && bash tests/smoke.sh >/dev/null) && ok "Smoke test" || bad "Smoke test failed"; fi');
-    p('if [ -x "$SPOTLIGHT_DIR/integrations/preflight.py" ] || [ -f "$SPOTLIGHT_DIR/integrations/preflight.py" ]; then (cd "$SPOTLIGHT_DIR" && set -a && . .env && set +a && python3 integrations/preflight.py --text >/dev/null) && ok "Integration preflight" || bad "Integration preflight reported issues"; fi');
-    p('if [ "$fail" -eq 0 ]; then printf "\\nSpotlight doctor: OK\\n"; else printf "\\nSpotlight doctor: failed\\n"; fi');
-    p('exit "$fail"');
-    p('DOCTOR_EOF');
-    p('chmod +x "$HOME/.local/bin/spotlight-doctor"');
-    p('');
-    p('cat > "$HOME/.local/bin/spotlight-update" <<\'UPDATE_EOF\'');
-    p('#!/usr/bin/env bash');
-    p('set -euo pipefail');
-    p('expand_path() {');
-    p('  local input="$1"');
-    p('  if [ "$input" = "~" ]; then printf "%s\\n" "$HOME";');
-    p('  elif [[ "$input" == "~/"* ]]; then printf "%s/%s\\n" "$HOME" "${input#~/}";');
-    p('  else printf "%s\\n" "$input"; fi');
-    p('}');
-    p('SPOTLIGHT_DIR_DEFAULT_INPUT=' + shellEscape(cfg.install_path));
-    p('SPOTLIGHT_DIR_DEFAULT="$(expand_path "$SPOTLIGHT_DIR_DEFAULT_INPUT")"');
-    p('SPOTLIGHT_DIR="${SPOTLIGHT_DIR:-$SPOTLIGHT_DIR_DEFAULT}"');
-    p('log_dir="$SPOTLIGHT_DIR/.spotlight/logs"');
-    p('mkdir -p "$log_dir"');
-    p('log="$log_dir/update.log"');
-    p('exec >>"$log" 2>&1');
-    p('echo ""');
-    p('date');
-    p('[ -d "$SPOTLIGHT_DIR/.git" ] || { echo "Spotlight repo missing: $SPOTLIGHT_DIR"; exit 1; }');
-    p('cd "$SPOTLIGHT_DIR"');
-    p('if ! git diff --quiet || ! git diff --cached --quiet; then echo "Spotlight has local uncommitted changes; skipping update."; exit 0; fi');
-    p('before="$(git rev-parse HEAD)"');
-    p('git fetch origin main');
-    p('if git merge-base --is-ancestor HEAD origin/main; then');
-    p('  git merge --ff-only origin/main');
-    p('  after="$(git rev-parse HEAD)"');
-    p('  echo "Spotlight $before -> $after"');
-    p('else');
-    p('  echo "Spotlight has local commits or divergent history; skipping update."');
-    p('  exit 0');
-    p('fi');
-    p('if "$HOME/.local/bin/spotlight-doctor"; then');
-    p('  echo "doctor passed"');
-    p('else');
-    p('  echo "doctor failed after update; rolling back to $before"');
-    p('  git reset --hard "$before"');
-    p('  exit 1');
-    p('fi');
-    p('echo "update complete"');
-    p('UPDATE_EOF');
-    p('chmod +x "$HOME/.local/bin/spotlight-update"');
-    p('printf "%s✓%s spotlight doctor/update wrappers installed\\n" "$_c_green" "$_c_reset"');
-    p('');
-
-    p('# ── Install spotlight shell command ──');
-    p('SHELL_RC=""');
-    p('case "$SHELL" in');
-    p('  */zsh) SHELL_RC="$HOME/.zshrc" ;;');
-    p('  */bash) SHELL_RC="$HOME/.bashrc" ;;');
-    p('  *) SHELL_RC="$HOME/.profile" ;;');
-    p('esac');
-    p('');
-    p('touch "$SHELL_RC"');
-    p('tmp_rc="$(mktemp)"');
-    p('awk \'');
-    p('  /^# SPOTLIGHT-BEGIN/ { skip=1; next }');
-    p('  /^# SPOTLIGHT-END/ { skip=0; next }');
-    p('  !skip { print }');
-    p('\' "$SHELL_RC" > "$tmp_rc"');
-    p('mv "$tmp_rc" "$SHELL_RC"');
-    p('echo "→ Writing \\"spotlight\\" command to $SHELL_RC"');
-    p('{');
-    p('  echo ""');
-    p('  echo "# SPOTLIGHT-BEGIN — added by setup.html installer"');
-    p('  printf "export SPOTLIGHT_DIR=%q\\n" "$SPOTLIGHT_DIR"');
-    p('  cat <<\'SHELL_EOF\'');
-    p('export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"');
-    p('spotlight() {');
-    p('  local dir="${SPOTLIGHT_DIR:-$HOME/spotlight}"');
-    p('  if [ ! -d "$dir" ]; then');
-    p('    echo "Spotlight not installed at $dir. Re-run the installer." >&2');
-    p('    return 1');
-    p('  fi');
-    p('  case "${1:-}" in');
-    p('    update)');
-    p('      SPOTLIGHT_DIR="$dir" "$HOME/.local/bin/spotlight-update"');
-    p('      ;;');
-    p('    doctor)');
-    p('      SPOTLIGHT_DIR="$dir" "$HOME/.local/bin/spotlight-doctor"');
-    p('      ;;');
-    p('    --help|-h|help)');
-    p('      cat <<HELP');
-    p('Usage: spotlight [subcommand]');
-    p('');
-    p('  (no arg)   Launch the configured runtime and start investigating');
-    p('  update     Fetch origin/main, fast-forward only, then run doctor');
-    p('  doctor     Run the smoke test (checks structure, schemas, preflights)');
-    p('  help       This message');
-    p('HELP');
-    p('      return 0');
-    p('      ;;');
-    p('  esac');
-    p('  (cd "$dir" && { [ -f .env ] && set -a && source .env && set +a; } && \\');
-    p('    case "$(sed -n \'s/.*"runtime": *"\\([^"]*\\)".*/\\1/p\' .spotlight-config.json 2>/dev/null | head -1)" in');
-    Object.entries(RUNTIMES).forEach(([id, r]) => {
-      p('      ' + id + ') ' + r.bin + ' ;;');
-    });
-    p('      *) echo "Unknown runtime in .spotlight-config.json" >&2; return 1 ;;');
-    p('    esac)');
-    p('}');
-    p('# SPOTLIGHT-END');
-    p('SHELL_EOF');
-    p('} >> "$SHELL_RC"');
-    p('');
-
-    p('step "Preflight"');
-    p('set -a; source "$SPOTLIGHT_DIR/.env"; set +a');
-    p('python3 "$SPOTLIGHT_DIR/integrations/preflight.py" --text || true');
-    p('');
-
-    p('echo ""');
-    p('echo "${_c_green}${_c_bold}  ╔════════════════════════════════════════════════╗${_c_reset}"');
-    p('echo "${_c_green}${_c_bold}  ║   ✓  Spotlight installed                       ║${_c_reset}"');
-    p('echo "${_c_green}${_c_bold}  ╚════════════════════════════════════════════════╝${_c_reset}"');
-    p('echo ""');
-    p('echo "  Open a new terminal window and type:"');
-    p('echo ""');
-    p('echo "    ${_c_bold}spotlight${_c_reset}"');
-    p('echo ""');
-    p('echo "  Then tell the agent: ${_c_dim}Start a Spotlight investigation on <your lead>${_c_reset}"');
-    p('echo ""');
-    p('echo "  Docs: $SPOTLIGHT_DIR/docs/README.md"');
-    p('echo ""');
-
-    return lines.join('\n') + '\n';
+  function buildCommandScript(cfg) {
+    // 3-line wrapper for the downloadable .command file. Fetches the same
+    // install-spotlight.sh as the paste path — single source of truth.
+    const block = buildExportBlock(cfg);
+    const b64 = utf8Base64(block);
+    return `#!/usr/bin/env bash\nexport SPOTLIGHT_CONFIG='${b64}'\ncurl -fsSL ${INSTALLER_URL} | bash\n`;
   }
 
   // --- Minimal hand-rolled zip (uncompressed, single file, unix exec bit) ---
@@ -2597,11 +1967,13 @@ Setup is complete. Open a new terminal and run \`spotlight\`. Then ask it to sta
       return;
     }
 
-    const script = buildScript(cfg);
-    scriptPreview.textContent = script;
+    const oneLiner = buildOneLiner(cfg);
+    const commandScript = buildCommandScript(cfg);
+    scriptPreview.textContent = oneLiner;
     installOutput.classList.remove('hidden');
     installOutput.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    installOutput.dataset.script = script;
+    installOutput.dataset.script = oneLiner;
+    installOutput.dataset.command = commandScript;
   });
 
   copyBtn.addEventListener('click', async () => {
@@ -2621,7 +1993,7 @@ Setup is complete. Open a new terminal and run \`spotlight\`. Then ask it to sta
   });
 
   downloadBtn.addEventListener('click', () => {
-    const script = installOutput.dataset.script || '';
+    const script = installOutput.dataset.command || '';
     const zip = buildZip('spotlight-setup.command', script);
     const blob = new Blob([zip], { type: 'application/zip' });
     const url = URL.createObjectURL(blob);

--- a/tests/install-spotlight-smoke.sh
+++ b/tests/install-spotlight-smoke.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Smoke test: run install-spotlight.sh --dry-run against four fixture configs
+# covering the cartesian product the installer must support. Assertions
+# check that each combo prints the right key install actions without
+# touching the filesystem or running brew/npm/curl.
+#
+# Usage: bash tests/install-spotlight-smoke.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+INSTALLER="$(pwd)/install-spotlight.sh"
+[ -f "$INSTALLER" ] || { echo "install-spotlight.sh not found at $INSTALLER" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+
+mkb64() {
+  # Args: KEY=VAL ... ; emits base64 of `export K='V'` lines.
+  python3 -c "
+import base64, sys, shlex
+fields = sys.argv[1:]
+out = []
+for f in fields:
+    k, _, v = f.partition('=')
+    out.append(f\"export {k}={shlex.quote(v)}\")
+print(base64.b64encode('\n'.join(out).encode('utf-8')).decode('ascii'))
+" "$@"
+}
+
+check_combo() {
+  local label="$1"; shift
+  local b64; b64=$(mkb64 "$@")
+  local out
+  if ! out=$(SPOTLIGHT_CONFIG="$b64" bash "$INSTALLER" --dry-run 2>&1); then
+    echo "✗ $label  installer exited non-zero"
+    echo "$out" | tail -10 | sed 's/^/    /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  # Run the per-combo assertions passed via global ASSERTIONS array.
+  local missing=()
+  for needle in "${ASSERTIONS[@]}"; do
+    if ! printf '%s' "$out" | grep -qF "$needle"; then
+      missing+=("$needle")
+    fi
+  done
+  if [ ${#missing[@]} -ne 0 ]; then
+    echo "✗ $label  missing expected output:"
+    for m in "${missing[@]}"; do echo "    - $m"; done
+    FAIL=$((FAIL + 1))
+  else
+    echo "✓ $label  ${#ASSERTIONS[@]} assertions matched"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# Common base config — every combo needs these keys.
+BASE=(
+  SPOTLIGHT_DIR_INPUT='~/Code/spotlight-test'
+  SPOTLIGHT_VAULT_INPUT='~/Vaults/spotlight-test'
+  SPOTLIGHT_VAULT_APP='obsidian'
+  SPOTLIGHT_INT_BROWSERUSE='false'
+  SPOTLIGHT_INT_JUNKIPEDIA='false'
+  SPOTLIGHT_INT_UNPAYWALL='false'
+  FIRECRAWL_API_KEY='fc-test'
+  OSINT_NAV_API_KEY='nav-test'
+)
+
+# --- 1. cloud / claude ---
+ASSERTIONS=(
+  "━━ Prerequisites ━━"
+  "━━ Claude Code ━━"
+  "AGENTS.md linked as CLAUDE.md"
+  "DRY-RUN: write .env"
+  "DRY-RUN: write spotlight-doctor"
+  "Spotlight installed"
+)
+check_combo "cloud/claude" "${BASE[@]}" \
+  SPOTLIGHT_MODE=cloud SPOTLIGHT_RUNTIME=claude
+
+# --- 2. cloud / opencode-openrouter ---
+ASSERTIONS=(
+  "━━ OpenCode (provider: openrouter) ━━"
+  "DRY-RUN: symlink"
+  ".config/opencode/skills/"
+  "DRY-RUN: write .env"
+  "Spotlight installed"
+)
+check_combo "cloud/opencode-openrouter" "${BASE[@]}" \
+  SPOTLIGHT_MODE=cloud SPOTLIGHT_RUNTIME=opencode \
+  SPOTLIGHT_OPENCODE_PROVIDER=openrouter \
+  SPOTLIGHT_CLOUD_KEY_VAR=OPENROUTER_API_KEY \
+  SPOTLIGHT_CLOUD_KEY=sk-or-test
+
+# --- 3. local / llamacpp / opencode ---
+ASSERTIONS=(
+  "━━ Local inference (llama-server) ━━"
+  "━━ Agent harness (opencode CLI) ━━"
+  "DRY-RUN: merge llamacpp provider into"
+  "127.0.0.1:8080/v1"
+  "DRY-RUN: write ~/.local/bin/spotlight-local for llamacpp/opencode"
+  "Spotlight installed"
+)
+check_combo "local/llamacpp/opencode" "${BASE[@]}" \
+  SPOTLIGHT_MODE=local SPOTLIGHT_RUNTIME=local \
+  SPOTLIGHT_LOCAL_SERVER=llamacpp SPOTLIGHT_LOCAL_MODEL=qwen27b \
+  SPOTLIGHT_AGENT=opencode SPOTLIGHT_OPENCODE_INTERFACE=cli \
+  SPOTLIGHT_MODEL_REPO='HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive'
+
+# --- 4. local / llamacpp / pi ---
+# The Pi branch prompts interactively (read -r ans </dev/tty), so we feed "y"
+# on stdin via process substitution to confirm proceeding past the warning.
+# But under --dry-run the prompt is skipped. Verify the warning still prints.
+ASSERTIONS=(
+  "━━ Local inference (llama-server) ━━"
+  "Pi has no native sub-agents."
+  "weakening the verification independence guarantee"
+  "━━ Agent harness (Pi) ━━"
+  "DRY-RUN: write"
+  "spotlight-local for llamacpp/pi"
+  "Spotlight installed"
+)
+check_combo "local/llamacpp/pi" "${BASE[@]}" \
+  SPOTLIGHT_MODE=local SPOTLIGHT_RUNTIME=local \
+  SPOTLIGHT_LOCAL_SERVER=llamacpp SPOTLIGHT_LOCAL_MODEL=gemma \
+  SPOTLIGHT_AGENT=pi SPOTLIGHT_OPENCODE_INTERFACE=cli \
+  SPOTLIGHT_MODEL_REPO='unsloth/gemma-4-26B-A4B-it-GGUF'
+
+# --- Bonus: missing-config rejection ---
+if SPOTLIGHT_CONFIG="" bash "$INSTALLER" --dry-run 2>/dev/null; then
+  echo "✗ empty-config rejection  installer should fail when SPOTLIGHT_CONFIG unset"
+  FAIL=$((FAIL + 1))
+else
+  echo "✓ empty-config rejection  installer rejects missing SPOTLIGHT_CONFIG"
+  PASS=$((PASS + 1))
+fi
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+exit "$FAIL"

--- a/tests/setup-generator-check.js
+++ b/tests/setup-generator-check.js
@@ -1,73 +1,57 @@
-// Generator check: extracts the buildScript() function + RUNTIMES + helpers
-// from setup.html and synthesizes install scripts for all runtime+provider
-// configs, verifying each produces syntactically valid bash.
+// Generator check: extracts buildExportBlock / buildOneLiner / buildCommandScript
+// from setup.html and verifies the install one-liner + .command wrapper shape
+// for every supported runtime/agent combo. Also validates the agent-manifest
+// path (separate "let an agent install for you" zip).
 //
 // Run via: node tests/setup-generator-check.js
 //
-// Exits 0 on all pass, 1 if any config fails bash -n.
+// Exits 0 on all pass, 1 if any config fails.
 
 const fs = require("fs");
-const { execSync } = require("child_process");
 const path = require("path");
 
 const ROOT = path.resolve(__dirname, "..");
 const html = fs.readFileSync(path.join(ROOT, "setup.html"), "utf8");
 
-const runtimesMatch = html.match(/const RUNTIMES = \{[\s\S]*?\n  \};/);
-const providersMatch = html.match(
-  /const OPENCODE_PROVIDERS = \{[\s\S]*?\n  \};/,
-);
-const shellEscapeMatch = html.match(/function shellEscape[\s\S]*?\n  \}/);
-const buildScriptMatch = html.match(
-  /function buildScript\(cfg\)[\s\S]*?return lines\.join\('\\n'\) \+ '\\n';\n  \}/,
-);
-const providerEnvVarsMatch = html.match(/function providerEnvVars[\s\S]*?\n  \}/);
-const envValuesMatch = html.match(/function envValues[\s\S]*?\n  \}/);
-const buildAgentManifestMatch = html.match(
-  /function buildAgentManifest\(cfg\)[\s\S]*?\n  \}/,
-);
-const buildAgentPromptMatch = html.match(
-  /function buildAgentPrompt\(manifest\)[\s\S]*?\n  \}/,
-);
-
-if (
-  !runtimesMatch ||
-  !providersMatch ||
-  !shellEscapeMatch ||
-  !buildScriptMatch ||
-  !providerEnvVarsMatch ||
-  !envValuesMatch ||
-  !buildAgentManifestMatch ||
-  !buildAgentPromptMatch
-) {
-  console.error("✗ Could not extract required JS blocks from setup.html");
-  console.error("  runtimes:", !!runtimesMatch);
-  console.error("  providers:", !!providersMatch);
-  console.error("  shellEscape:", !!shellEscapeMatch);
-  console.error("  buildScript:", !!buildScriptMatch);
-  console.error("  providerEnvVars:", !!providerEnvVarsMatch);
-  console.error("  envValues:", !!envValuesMatch);
-  console.error("  buildAgentManifest:", !!buildAgentManifestMatch);
-  console.error("  buildAgentPrompt:", !!buildAgentPromptMatch);
-  process.exit(1);
+// --- Extract pure functions from setup.html. We rely on the file's
+// consistent 2-space indentation: each top-level helper is `  function …`
+// and ends with `\n  }`. This avoids needing a real JS parser for what is
+// otherwise a tricky string/regex/template-literal-aware brace match. ---
+function grabFn(name) {
+  const re = new RegExp(`  function ${name}\\b[\\s\\S]*?\\n  \\}`);
+  const m = html.match(re);
+  return m ? m[0] : null;
 }
 
+const fnSources = {
+  shellEscape:        grabFn("shellEscape"),
+  buildExportBlock:   grabFn("buildExportBlock"),
+  utf8Base64:         grabFn("utf8Base64"),
+  buildOneLiner:      grabFn("buildOneLiner"),
+  buildCommandScript: grabFn("buildCommandScript"),
+  buildAgentManifest: grabFn("buildAgentManifest"),
+  buildAgentPrompt:   grabFn("buildAgentPrompt"),
+  providerEnvVars:    grabFn("providerEnvVars"),
+  envValues:          grabFn("envValues"),
+};
+const installerUrlMatch = html.match(/const INSTALLER_URL = '[^']+';/);
+const runtimesMatch     = html.match(/const RUNTIMES = \{[\s\S]*?\n  \};/);
+const providersMatch    = html.match(/const OPENCODE_PROVIDERS = \{[\s\S]*?\n  \};/);
+
+for (const [k, v] of Object.entries(fnSources)) {
+  if (!v) { console.error(`✗ Could not extract function ${k} from setup.html`); process.exit(1); }
+}
+for (const [k, v] of Object.entries({ INSTALLER_URL: installerUrlMatch, RUNTIMES: runtimesMatch, OPENCODE_PROVIDERS: providersMatch })) {
+  if (!v) { console.error(`✗ Could not extract const ${k} from setup.html`); process.exit(1); }
+}
+
+// --- Eval the extracted pieces into this scope. The function declarations
+// here become live bindings on `globalThis` so we can call them below. ---
 eval(
-  runtimesMatch[0] +
-    "\n" +
-    providersMatch[0] +
-    "\n" +
-    shellEscapeMatch[0] +
-    "\n" +
-    buildScriptMatch[0] +
-    "\n" +
-    providerEnvVarsMatch[0] +
-    "\n" +
-    envValuesMatch[0] +
-    "\n" +
-    buildAgentManifestMatch[0] +
-    "\n" +
-    buildAgentPromptMatch[0],
+  runtimesMatch[0] + "\n" +
+  providersMatch[0] + "\n" +
+  installerUrlMatch[0] + "\n" +
+  Object.values(fnSources).join("\n"),
 );
 
 const baseCfg = {
@@ -84,205 +68,172 @@ const baseCfg = {
 };
 
 const configs = [
-  {
-    label: "local/ollama",
-    mode: "local",
-    runtime: "local",
-    local_model: "gemma",
-    local_server: "ollama",
-    opencode_interface: "cli",
-    opencode_provider: null,
-    cloud_key: "",
-    cloud_key_var: "",
-    model_repo: "unsloth/gemma-4-26B-A4B-it-GGUF",
-  },
-  {
-    label: "local/llamacpp",
-    mode: "local",
-    runtime: "local",
-    local_model: "qwen27b",
-    local_server: "llamacpp",
-    opencode_interface: "cli",
-    opencode_provider: null,
-    cloud_key: "",
-    cloud_key_var: "",
-    model_repo: "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
-  },
-  {
-    label: "local/ollama-qwen",
-    mode: "local",
-    runtime: "local",
-    local_model: "qwen27b",
-    local_server: "ollama",
-    opencode_interface: "cli",
-    opencode_provider: null,
-    cloud_key: "",
-    cloud_key_var: "",
-    model_repo: "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive",
-  },
-  {
-    label: "claude",
-    mode: "cloud",
-    runtime: "claude",
-    opencode_provider: null,
-    cloud_key: "",
-    cloud_key_var: "",
-  },
-  {
-    label: "gemini",
-    mode: "cloud",
-    runtime: "gemini",
-    opencode_provider: null,
-    cloud_key: "",
-    cloud_key_var: "",
-  },
-  {
-    label: "codex",
-    mode: "cloud",
-    runtime: "codex",
-    opencode_provider: null,
-    cloud_key: "",
-    cloud_key_var: "",
-  },
-  {
-    label: "opencode/openrouter",
-    mode: "cloud",
-    runtime: "opencode",
-    opencode_provider: "openrouter",
-    cloud_key: "sk-or-v1-x",
-    cloud_key_var: "OPENROUTER_API_KEY",
-  },
-  {
-    label: "opencode/fireworks",
-    mode: "cloud",
-    runtime: "opencode",
-    opencode_provider: "fireworks",
-    cloud_key: "fw-x",
-    cloud_key_var: "FIREWORKS_API_KEY",
-  },
-  {
-    label: "opencode/together",
-    mode: "cloud",
-    runtime: "opencode",
-    opencode_provider: "together",
-    cloud_key: "tg-x",
-    cloud_key_var: "TOGETHER_API_KEY",
-  },
+  { label: "local/llamacpp/opencode", mode: "local", runtime: "local",
+    local_model: "qwen27b", local_server: "llamacpp", agent: "opencode",
+    opencode_interface: "cli", opencode_provider: null, cloud_key: "", cloud_key_var: "",
+    model_repo: "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive" },
+  { label: "local/llamacpp/pi", mode: "local", runtime: "local",
+    local_model: "qwen27b", local_server: "llamacpp", agent: "pi",
+    opencode_interface: "cli", opencode_provider: null, cloud_key: "", cloud_key_var: "",
+    model_repo: "HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive" },
+  { label: "local/ollama/opencode", mode: "local", runtime: "local",
+    local_model: "gemma", local_server: "ollama", agent: "opencode",
+    opencode_interface: "cli", opencode_provider: null, cloud_key: "", cloud_key_var: "",
+    model_repo: "unsloth/gemma-4-26B-A4B-it-GGUF" },
+  { label: "local/ollama/pi", mode: "local", runtime: "local",
+    local_model: "gemma", local_server: "ollama", agent: "pi",
+    opencode_interface: "cli", opencode_provider: null, cloud_key: "", cloud_key_var: "",
+    model_repo: "unsloth/gemma-4-26B-A4B-it-GGUF" },
+  { label: "cloud/claude", mode: "cloud", runtime: "claude",
+    agent: null, opencode_provider: null, cloud_key: "", cloud_key_var: "" },
+  { label: "cloud/gemini", mode: "cloud", runtime: "gemini",
+    agent: null, opencode_provider: null, cloud_key: "", cloud_key_var: "" },
+  { label: "cloud/codex", mode: "cloud", runtime: "codex",
+    agent: null, opencode_provider: null, cloud_key: "", cloud_key_var: "" },
+  { label: "cloud/opencode-openrouter", mode: "cloud", runtime: "opencode",
+    agent: null, opencode_provider: "openrouter", cloud_key: "sk-or-v1-x", cloud_key_var: "OPENROUTER_API_KEY" },
+  { label: "cloud/opencode-fireworks", mode: "cloud", runtime: "opencode",
+    agent: null, opencode_provider: "fireworks", cloud_key: "fw-x", cloud_key_var: "FIREWORKS_API_KEY" },
+  { label: "cloud/opencode-together", mode: "cloud", runtime: "opencode",
+    agent: null, opencode_provider: "together", cloud_key: "tg-x", cloud_key_var: "TOGETHER_API_KEY" },
 ];
 
-let pass = 0,
-  fail = 0;
+let pass = 0, fail = 0;
 
-function assertFragment(script, label, needle) {
-  if (!script.includes(needle)) {
-    console.log(`✗ ${label.padEnd(24)} missing ${needle}`);
-    return false;
-  }
-  return true;
+function decodeBlock(oneLiner) {
+  const m = oneLiner.match(/SPOTLIGHT_CONFIG='([^']+)'/);
+  if (!m) return null;
+  return Buffer.from(m[1], "base64").toString("utf8");
+}
+
+function hasExport(block, key, value) {
+  // Matches `export KEY='<value>'` exactly (value is the raw form input).
+  const escaped = "'" + value.replace(/'/g, "'\\''") + "'";
+  return block.includes(`export ${key}=${escaped}`);
 }
 
 for (const c of configs) {
   const cfg = { ...baseCfg, ...c };
-  const script = buildScript(cfg);
-  const required = [
-    "git fetch origin main",
-    "git merge --ff-only origin/main",
-    "spotlight-update",
-    "spotlight-doctor",
-    "qmd collection add \"$SPOTLIGHT_VAULT_PATH\" --name spotlight",
-    "write_env_var FIRECRAWL_API_KEY",
-    "write_env_var OSINT_NAV_API_KEY",
-    "SPOTLIGHT-BEGIN",
-    "awk '",
-    'export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"',
-  ];
+  const oneLiner = buildOneLiner(cfg);
+  const cmdScript = buildCommandScript(cfg);
   let ok = true;
-  for (const needle of required) ok = assertFragment(script, c.label, needle) && ok;
-  if (script.includes("git pull --no-rebase --autostash origin main")) {
-    console.log(`✗ ${c.label.padEnd(24)} contains unsafe git pull --autostash`);
+
+  // One-liner shape
+  if (!oneLiner.startsWith("curl -fsSL https://raw.githubusercontent.com/buriedsignals/spotlight/main/install-spotlight.sh")) {
+    console.log(`✗ ${c.label.padEnd(28)} one-liner missing curl URL`);
     ok = false;
   }
-  if (c.runtime === "local" && !script.includes("spotlight-local")) {
-    console.log(`✗ ${c.label.padEnd(24)} local runtime does not install spotlight-local`);
+  if (!oneLiner.includes("SPOTLIGHT_CONFIG='")) {
+    console.log(`✗ ${c.label.padEnd(28)} one-liner missing SPOTLIGHT_CONFIG env`);
     ok = false;
   }
-  if (c.label === "local/ollama") {
-    const ollamaRequired = [
-      "hf.co/unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M",
-      "SPOTLIGHT_OLLAMA_ALIAS",
-      "spotlight-gemma4-q4",
-      'ollama create "$SPOTLIGHT_OLLAMA_ALIAS" -f "$TMP_MODELFILE"',
-      'opencode --model "ollama/$SPOTLIGHT_OLLAMA_ALIAS" "$@"',
-      'SPOTLIGHT_DIR_DEFAULT="$(expand_path "$SPOTLIGHT_DIR_DEFAULT_INPUT")"',
-      "write_env_var OLLAMA_MODEL",
-      '.provider["ollama"] = {"npm":"@ai-sdk/openai-compatible"',
-      '"options":{"baseURL":$base}',
-    ];
-    for (const needle of ollamaRequired) ok = assertFragment(script, c.label, needle) && ok;
-    if (script.includes("ollama-ai-provider-v2")) {
-      console.log(`✗ ${c.label.padEnd(24)} uses Ollama-native provider that calls /v1/chat`);
-      ok = false;
-    }
-    if (script.includes("11434/v1/chat/completions")) {
-      console.log(`✗ ${c.label.padEnd(24)} hard-codes chat/completions into baseURL`);
-      ok = false;
-    }
-    if (script.includes('ollama pull "$MODEL" >/dev/null 2>&1 || true')) {
-      console.log(`✗ ${c.label.padEnd(24)} still swallows Ollama pull failure`);
-      ok = false;
-    }
-  }
-  if (c.label === "local/ollama-qwen") {
-    const qwenRequired = [
-      "hf.co/HauhauCS/Qwen3.6-27B-Uncensored-HauhauCS-Aggressive:IQ2_M",
-      "spotlight-qwen36-27b-q4",
-      'ollama create "$SPOTLIGHT_OLLAMA_ALIAS" -f "$TMP_MODELFILE"',
-      'opencode --model "ollama/$SPOTLIGHT_OLLAMA_ALIAS" "$@"',
-      "write_env_var OLLAMA_MODEL",
-      '.provider["ollama"] = {"npm":"@ai-sdk/openai-compatible"',
-      '"options":{"baseURL":$base}',
-    ];
-    for (const needle of qwenRequired) ok = assertFragment(script, c.label, needle) && ok;
-    if (script.includes("ollama-ai-provider-v2")) {
-      console.log(`✗ ${c.label.padEnd(24)} uses Ollama-native provider that calls /v1/chat`);
-      ok = false;
-    }
-    if (script.includes("11434/v1/chat/completions")) {
-      console.log(`✗ ${c.label.padEnd(24)} hard-codes chat/completions into baseURL`);
-      ok = false;
-    }
-  }
-  if (c.runtime === "opencode" && !script.includes("opencode loads Spotlight skills")) {
-    console.log(`✗ ${c.label.padEnd(24)} opencode skills not linked`);
+  if (!oneLiner.endsWith(" bash")) {
+    console.log(`✗ ${c.label.padEnd(28)} one-liner does not end with 'bash'`);
     ok = false;
   }
-  if (!ok) {
-    fail++;
-    continue;
+
+  // .command wrapper shape (3-line bash that fetches install-spotlight.sh)
+  const cmdLines = cmdScript.trim().split("\n");
+  if (cmdLines.length !== 3 || cmdLines[0] !== "#!/usr/bin/env bash") {
+    console.log(`✗ ${c.label.padEnd(28)} .command wrapper not 3 lines with shebang`);
+    ok = false;
   }
-  const tmp = `/tmp/setup-gen-${c.label.replace(/\//g, "-")}.sh`;
-  fs.writeFileSync(tmp, script);
-  try {
-    execSync(`bash -n "${tmp}"`, { stdio: "pipe" });
-    console.log(`✓ ${c.label.padEnd(24)} ${script.length} bytes`);
+  if (!cmdScript.includes("SPOTLIGHT_CONFIG='")) {
+    console.log(`✗ ${c.label.padEnd(28)} .command wrapper missing config export`);
+    ok = false;
+  }
+
+  // Decode + verify the export block
+  const block = decodeBlock(oneLiner);
+  if (!block) { console.log(`✗ ${c.label.padEnd(28)} cannot decode base64 from one-liner`); ok = false; }
+  else {
+    if (!hasExport(block, "SPOTLIGHT_MODE", cfg.mode)) {
+      console.log(`✗ ${c.label.padEnd(28)} block missing SPOTLIGHT_MODE=${cfg.mode}`);
+      ok = false;
+    }
+    if (!hasExport(block, "SPOTLIGHT_RUNTIME", cfg.runtime)) {
+      console.log(`✗ ${c.label.padEnd(28)} block missing SPOTLIGHT_RUNTIME=${cfg.runtime}`);
+      ok = false;
+    }
+    if (!hasExport(block, "FIRECRAWL_API_KEY", cfg.firecrawl_key)) {
+      console.log(`✗ ${c.label.padEnd(28)} block missing FIRECRAWL_API_KEY`);
+      ok = false;
+    }
+    if (!hasExport(block, "OSINT_NAV_API_KEY", cfg.nav_key)) {
+      console.log(`✗ ${c.label.padEnd(28)} block missing OSINT_NAV_API_KEY`);
+      ok = false;
+    }
+    if (cfg.mode === "local") {
+      if (!hasExport(block, "SPOTLIGHT_LOCAL_SERVER", cfg.local_server)) {
+        console.log(`✗ ${c.label.padEnd(28)} block missing SPOTLIGHT_LOCAL_SERVER=${cfg.local_server}`);
+        ok = false;
+      }
+      if (!hasExport(block, "SPOTLIGHT_AGENT", cfg.agent)) {
+        console.log(`✗ ${c.label.padEnd(28)} block missing SPOTLIGHT_AGENT=${cfg.agent}`);
+        ok = false;
+      }
+      if (!hasExport(block, "SPOTLIGHT_MODEL_REPO", cfg.model_repo)) {
+        console.log(`✗ ${c.label.padEnd(28)} block missing SPOTLIGHT_MODEL_REPO`);
+        ok = false;
+      }
+    }
+    if (cfg.cloud_key_var) {
+      if (!hasExport(block, "SPOTLIGHT_CLOUD_KEY_VAR", cfg.cloud_key_var)) {
+        console.log(`✗ ${c.label.padEnd(28)} block missing SPOTLIGHT_CLOUD_KEY_VAR=${cfg.cloud_key_var}`);
+        ok = false;
+      }
+      if (!hasExport(block, "SPOTLIGHT_CLOUD_KEY", cfg.cloud_key)) {
+        console.log(`✗ ${c.label.padEnd(28)} block missing SPOTLIGHT_CLOUD_KEY`);
+        ok = false;
+      }
+    }
+  }
+
+  if (ok) {
+    console.log(`✓ ${c.label.padEnd(28)} one-liner=${oneLiner.length}B  block=${block ? block.length : "?"}B`);
     pass++;
-  } catch (e) {
-    console.log(
-      `✗ ${c.label.padEnd(24)} ${(e.stderr || e).toString().split("\n")[0]}`,
-    );
+  } else {
     fail++;
   }
 }
 
+// --- Injection-resistance check ---
+const injCfg = {
+  ...baseCfg, mode: "cloud", runtime: "claude", agent: null,
+  opencode_provider: null, cloud_key: "", cloud_key_var: "",
+  firecrawl_key: "fc-with-quote'and$dollar`backtick;rm-rf",
+};
+const injOneLiner = buildOneLiner(injCfg);
+const injBlock = decodeBlock(injOneLiner);
+if (injBlock && hasExport(injBlock, "FIRECRAWL_API_KEY", injCfg.firecrawl_key)) {
+  console.log("✓ injection-resistance         single-quote and shell metas survived round-trip safely");
+  pass++;
+} else {
+  console.log("✗ injection-resistance         malicious key did NOT survive base64+eval intact");
+  console.log("  expected:", injCfg.firecrawl_key);
+  console.log("  block excerpt:", injBlock ? injBlock.split("\n").find(l => l.includes("FIRECRAWL")) : "(no block)");
+  fail++;
+}
+
+// --- UTF-8 round-trip check ---
+const utf8Cfg = { ...baseCfg, mode: "cloud", runtime: "claude", agent: null,
+  opencode_provider: null, cloud_key: "", cloud_key_var: "",
+  vault_path: "/Users/x/Vaults/Schräge·Münzen" };
+const utf8Block = decodeBlock(buildOneLiner(utf8Cfg));
+if (utf8Block && utf8Block.includes("Schräge·Münzen")) {
+  console.log("✓ utf-8 round-trip             vault path preserved through TextEncoder+base64");
+  pass++;
+} else {
+  console.log("✗ utf-8 round-trip             unicode mangled");
+  fail++;
+}
+
+// --- Agent manifest path (unchanged from previous test) ---
 const manifestCfg = {
-  ...baseCfg,
-  mode: "cloud",
-  runtime: "opencode",
-  opencode_provider: "fireworks",
-  cloud_key: "fw-secret-test",
+  ...baseCfg, mode: "cloud", runtime: "opencode",
+  opencode_provider: "fireworks", cloud_key: "fw-secret-test",
   cloud_key_var: "FIREWORKS_API_KEY",
-  int_junkipedia: true,
-  junkipedia_key: "junk-secret-test",
+  int_junkipedia: true, junkipedia_key: "junk-secret-test",
 };
 const manifest = buildAgentManifest(manifestCfg);
 const prompt = buildAgentPrompt(manifest);
@@ -301,7 +252,7 @@ if (
   console.log("✗ agent prompt does not instruct agent setup from manifest values");
   fail++;
 } else {
-  console.log("✓ agent manifest/prompt      values included, prompt redacted");
+  console.log("✓ agent manifest/prompt        values included, prompt redacted");
   pass++;
 }
 


### PR DESCRIPTION
## Why

Two coupled problems in the current installer:

1. **Copy-paste into Terminal fails under zsh.** The 960-line bash script generated by `setup.html` (`buildScript()`) used bash-only constructs (`set -euo pipefail`, `[[ =~ ]]`, arrays, `$'\033[0m'`) that broke when zsh tokenized them line-by-line on paste. The `.command` double-click path worked only because the shebang dispatched to bash. Users got garbled "zrsch" errors instead of the installer banner.

2. **Local mode hard-wired opencode** as the agent harness. Pi (https://pi.dev) is a viable alternative for a leaner install — the user asked for it as an option.

## What changes

**`install-spotlight.sh`** (new, repo root) — extracted from `buildScript()`. Reads its config from `$SPOTLIGHT_CONFIG` (base64-encoded shell-export block), branches on `$SPOTLIGHT_AGENT` for opencode vs Pi. Has `--dry-run` mode for CI.

**`setup.html`** — `buildScript()` deleted (~960 lines). Replaced with `buildExportBlock()` + `buildOneLiner()` + `buildCommandScript()` (~25 lines). The paste payload is now a single line:

```
curl -fsSL .../install-spotlight.sh | SPOTLIGHT_CONFIG='<b64>' bash
```

Zsh tokenizes the pipeline + env-prefix cleanly; bash runs the body. The downloadable `.command` becomes a 3-line wrapper that fetches the same `install-spotlight.sh`. Single source of truth.

Adds an **agent picker** in the local section: opencode (recommended) vs Pi (minimal, no native sub-agents). The Pi branch installs `@mariozechner/pi-coding-agent` + `pi install npm:pi-llama-cpp` (community extension, gsanhueza, MIT) and writes `~/.pi/agent/settings.json` pointing at the running llama-server / Ollama endpoint.

**`docs/runtimes.md`** — Pi section updated. Replaced "write your own custom extension" with `pi install npm:pi-llama-cpp`. Authorship attribution corrected.

**`README.md`** — Added Pi to the supported-runtimes table; rewrote the inference-vs-agent split.

**`tests/setup-generator-check.js`** — Rewritten to validate the one-liner shape + base64 round-trip + injection resistance (single-quoted shell metas) + UTF-8 preservation (vault paths with non-ASCII). Asserts the export block contains the expected `SPOTLIGHT_*` keys for each form combo.

**`tests/install-spotlight-smoke.sh`** (new) — dry-runs `install-spotlight.sh` against four config combinations (cloud/claude, cloud/opencode-openrouter, local/llamacpp/opencode, local/llamacpp/pi) and checks key install actions appear in the right order.

## Architecture note

The new installer makes the layer split explicit. Two orthogonal choices for local mode:

- **Inference server** (one of): `llama-server` (llama.cpp), Ollama
- **Agent harness** (one of): opencode, Pi

Both Pi and opencode are clients that consume an OpenAI-compatible endpoint on `127.0.0.1:8080` (llama.cpp) or `:11434` (Ollama). Pi does not replace llama-server — `pi-llama-cpp` attaches to a running llama-server for model browsing/switching.

## Test plan

- [x] `node tests/setup-generator-check.js` — 13/13 pass
- [x] `bash tests/install-spotlight-smoke.sh` — 5/5 pass
- [x] `bash tests/smoke.sh` — 33/33 pass (no regression)
- [x] `bash tests/eval.sh` — 30/30 pass (no regression)
- [x] `bash -n install-spotlight.sh` — clean
- [x] Manual zsh paste of the generated one-liner — tokenizes correctly (no "zrsch")
- [x] End-to-end: generator → base64 → bash eval → install-spotlight.sh --dry-run for Pi/llamacpp combo — full pipeline produces the right output
- [x] Injection-resistance: `firecrawl_key="fc-with-quote'and$dollar`backtick;rm-rf"` survives base64 + eval as data, no spurious commands
- [x] UTF-8 round-trip: `Schräge·Münzen` vault path preserved byte-for-byte

## Out of scope

- Switching the default local agent from opencode to Pi — opencode stays default because sub-agent independence is load-bearing for Spotlight's verification model.
- Inference-only path (skip agent install) — installer remains opinionated; every local install gets a configured agent.
- POSIX-porting the install script — forcing bash via the one-liner is sufficient and lower-risk than translating ~700 lines of bash idioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)