### PR TITLE
Fix qwen27b /no_think: TEMPLATE override + opencode output limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ Skills are markdown playbooks loaded via `invoke-skill(skill_id)`. Each skill li
 | `review` | `skills/review/SKILL.md` | Post-Gate-1 HTML review artifact + structured feedback loop; re-spawns investigator on feedback submission | orchestrator, user |
 | `integrations` | `skills/integrations/SKILL.md` | Routing layer for external tool integrations — Browser Harness, browser-use, Junkipedia, Noosphere C2PA, OSINT Navigator, Unpaywall. Reads live preflight status, maps investigation tasks to integrations | investigator, fact-checker, orchestrator |
 | `ingest` | `skills/ingest/SKILL.md` | Knowledge archival — vault ingestion from case files | orchestrator, user |
+| `report-drafting` | `skills/report-drafting/SKILL.md` | Post-Gate-1 public-facing report.html drafting — phase-by-phase methodology, replication blocks, evidence ledger. Distinct from `review` (editorial loop) and `ingest` (vault archival). | orchestrator, user |
 | `monitoring` | `skills/monitoring/SKILL.md` | Monitoring orchestration — Mycroft passive signals, coJournalist projects/scouts, runtime-native fallbacks | orchestrator |
 | `provenance-signing` | `skills/provenance-signing/SKILL.md` | Build a case-level provenance manifest and optionally hand it to Noosphere C2PA signing before final report delivery | orchestrator, user |
 | `acquisition-graduation` | `skills/acquisition-graduation/SKILL.md` | Convert repeated Browser Harness acquisitions into durable source/domain guidance without secrets or brittle session details | investigator, fact-checker, orchestrator, user |

--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ Head-to-head on a 5-prompt subset of the same eval suite (with the `/no_think` w
 
 ### 27B thinking-mode workaround (built into the installer)
 
-Qwen 3.6 abliterated variants default to thinking mode and ignore the OpenAI-compat `think: false` payload field. Without disabling thinking, the model dumps reasoning into the API's `reasoning` field and leaves `content` empty unless `max_tokens` is generous (~4k+). On our first bench run the 27B returned 15/15 empty responses.
+Qwen 3.6 abliterated variants default to thinking mode and ignore the OpenAI-compat `think: false` payload field. Without disabling thinking, the model dumps reasoning into the API's `reasoning` field and leaves `content` empty unless `max_tokens` is generous (~16k+). On our first bench run the 27B returned 15/15 empty responses; with the fix below, end-to-end queries return ~7k chars of OSINT methodology with `finish_reason: stop`.
 
-The fix is Qwen's documented `/no_think` directive in the user message. The installer (`install-spotlight.sh`) writes this as a `SYSTEM` line into the Ollama Modelfile when the 27B is selected, so opencode / pi don't need to inject it per-request. After the install, your local 27B is `spotlight-qwen27b`, which is the Huihui base tag plus the `/no_think` system prompt baked in.
+The fix is two-part because Qwen's `/no_think` soft-switch alone isn't enough — the model still does substantial reasoning even when instructed not to:
+
+1. **TEMPLATE override in the Ollama Modelfile** — the installer rewrites the chat template for the `spotlight-qwen27b` alias to inject `/no_think` at the start of every user message during rendering. The naive approach of setting `SYSTEM "/no_think"` doesn't survive opencode/pi sending their own system message (skill prompts + AGENTS.md); the TEMPLATE-level injection is the layer that does. The base Qwen 3.5 RENDERER is preserved; our explicit TEMPLATE takes precedence in practice.
+
+2. **opencode `limit.output: 16384`** — the installer writes a per-model output cap into opencode's provider config so requests carry enough max_tokens for Qwen's ~10k reasoning + ~5k content footprint. Without this, opencode's default cap truncates inside the reasoning phase and `content` comes back empty.
+
+Both pieces are written automatically when `SPOTLIGHT_LOCAL_MODEL=qwen27b` flows through `install-spotlight.sh`. End-to-end verified against a real bench prompt with a harness-shaped system message before merge.
 
 ### What got dropped, and why
 

--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -371,15 +371,35 @@ if [ "$SPOTLIGHT_MODE" = "local" ]; then
       # (Huihui, HauhauCS) default to thinking mode and ignore the
       # OpenAI-compat `think:false` payload field. Without disabling
       # thinking, the model dumps reasoning into the `reasoning` field
-      # and leaves `content` empty until max_tokens is generous (~4k+).
-      # The /no_think directive in the user message is Qwen's documented
-      # soft-switch; we bake it into the alias as a system prompt so
-      # opencode / pi don't have to inject it per-request. Bench-verified:
-      # with /no_think the 27B scored 100.0 composite vs 91.2 for the 9B
-      # on a 5-prompt subset; without it, content was empty 15/15.
+      # and leaves `content` empty unless max_tokens is generous (~4k+).
+      #
+      # SYSTEM "/no_think" doesn't survive because opencode sends its
+      # own system message (skill prompts + AGENTS.md) which overrides
+      # the Modelfile's SYSTEM. The fix that DOES survive: override the
+      # chat TEMPLATE to inject /no_think at the START of every user
+      # message during rendering. The base Qwen 3.5 RENDERER is left in
+      # place (Ollama ignores TEMPLATE if RENDERER is set to a known
+      # value, but our explicit TEMPLATE here takes precedence in
+      # practice — verified end-to-end with a system+user request that
+      # mirrors opencode's actual traffic).
+      #
+      # The opencode config below also sets `limit.output: 16384` for
+      # this alias so requests carry enough max_tokens budget for the
+      # thinking + content to fit (Qwen burns ~10k tokens on reasoning
+      # for complex OSINT prompts even with /no_think).
       case "$SPOTLIGHT_LOCAL_MODEL" in
         qwen27b)
-          printf 'SYSTEM "/no_think"\n' >> "$TMP_MODELFILE"
+          cat >> "$TMP_MODELFILE" <<'NOMINK'
+TEMPLATE """{{- if .System }}<|im_start|>system
+{{ .System }}<|im_end|>
+{{ end }}{{- range .Messages }}<|im_start|>{{ .Role }}
+{{ if eq .Role "user" }}/no_think
+{{ end }}{{ .Content }}<|im_end|>
+{{ end }}<|im_start|>assistant
+"""
+PARAMETER stop "<|im_end|>"
+PARAMETER stop "<|im_start|>"
+NOMINK
           ;;
       esac
       ollama create "$SPOTLIGHT_OLLAMA_ALIAS" -f "$TMP_MODELFILE"
@@ -491,9 +511,20 @@ if [ "$SPOTLIGHT_MODE" = "local" ]; then
           '.provider["llama.cpp"] = {"npm":"@ai-sdk/openai-compatible","name":"llama-server (local)","options":{"baseURL":$base},"models":{($id):{"name":$name}}}' \
           "$OC_CFG" > "$TMP" && mv "$TMP" "$OC_CFG"
       else
-        jq --arg base "$LOCAL_BASE_URL" --arg id "$OLLAMA_ALIAS_DEFAULT" --arg name "$MODEL_LEAF (local Ollama)" \
-          '.provider["ollama"] = {"npm":"@ai-sdk/openai-compatible","name":"Ollama (local OpenAI-compatible)","options":{"baseURL":$base},"models":{($id):{"name":$name}}}' \
-          "$OC_CFG" > "$TMP" && mv "$TMP" "$OC_CFG"
+        # Per-model `limit.output` for the 27B because Qwen 3.6 thinking
+        # burns ~10k tokens of reasoning even with /no_think injected;
+        # without a generous output budget, content comes back empty.
+        # The 9B doesn't need this (no thinking mode), so we leave its
+        # limit unset and inherit opencode's default.
+        if [ "$SPOTLIGHT_LOCAL_MODEL" = "qwen27b" ]; then
+          jq --arg base "$LOCAL_BASE_URL" --arg id "$OLLAMA_ALIAS_DEFAULT" --arg name "$MODEL_LEAF (local Ollama)" \
+            '.provider["ollama"] = {"npm":"@ai-sdk/openai-compatible","name":"Ollama (local OpenAI-compatible)","options":{"baseURL":$base},"models":{($id):{"name":$name,"limit":{"output":16384}}}}' \
+            "$OC_CFG" > "$TMP" && mv "$TMP" "$OC_CFG"
+        else
+          jq --arg base "$LOCAL_BASE_URL" --arg id "$OLLAMA_ALIAS_DEFAULT" --arg name "$MODEL_LEAF (local Ollama)" \
+            '.provider["ollama"] = {"npm":"@ai-sdk/openai-compatible","name":"Ollama (local OpenAI-compatible)","options":{"baseURL":$base},"models":{($id):{"name":$name}}}' \
+            "$OC_CFG" > "$TMP" && mv "$TMP" "$OC_CFG"
+        fi
       fi
       printf "%s✓%s opencode.json updated with %s provider\n" "$_c_green" "$_c_reset" "$SPOTLIGHT_LOCAL_SERVER"
     fi

--- a/skills/report-drafting/SKILL.md
+++ b/skills/report-drafting/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: report-drafting
+description: Post-Gate-1 sub-skill for Spotlight — draft the journalist-grade public-facing report.html from a verified investigation. Distinct from the review skill (editorial feedback loop) and the ingest skill (knowledge-base archival). Ships a working report-template.html skeleton (CSS variables, novelty + confidence pill classes, .path replication-block per finding, inline .sources strip per finding) and the design discipline that produces it: phase-by-phase methodology section that absorbs the adversarial fact-check verdict table inside Phase 3 — not as a separate top-level section. Hybrid-aware — when invoked after a data-detective handover, methodology walks upstream (data-detective phases) and downstream (Spotlight phases) in one ordered trail. Editing protocol: never run greedy regex on the live HTML; use anchored read+edit. Triggers on draft the report, build the public report, journalist-grade output, hand-off report, or final report.html.
+version: "1.0"
+invocable_by: [orchestrator, user]
+requires: []
+---
+
+# report-drafting — Public-facing report deliverable
+
+Spotlight ships three HTML artifacts in different roles:
+
+| Skill | Output | Role |
+|---|---|---|
+| `review` | `review.html` | Self-contained editorial feedback loop — journalist inspects + submits feedback. Internal loop artifact. |
+| **`report-drafting`** | **`report.html`** | **Public-facing journalism artifact — designed deliverable for editors / publication.** |
+| `ingest` | (vault notes) | Knowledge-base archival in Obsidian / Tolaria / directory. |
+
+This skill builds `report.html`. Read `references/report-template.html` before drafting — it is the working skeleton.
+
+Invoked at Phase 5 (after Gate 1, before Phase 6 ingestion). Optional — the orchestrator presents it to the user as the choice between editorial-review-only and public-report-output. Mandatory when invoked via data-detective handover (data-detective stops at its Gate 1 and delegates the final report to Spotlight).
+
+---
+
+## Required deliverables
+
+| File | Audience | What it is |
+|---|---|---|
+| `cases/{project}/report.html` | Publication / external reader | Public-facing journalism artifact. Styled, scannable, with inline replication paths and archived primary sources. |
+| `cases/{project}/findings-report.md` | Editor / fact-checker | Narrative audit document. Plain prose + tables. Authoritative claim-by-claim record. |
+| `cases/{project}/evidence-map.json` | Audit / replication | Machine-readable ledger: claim → sources → archive URLs. |
+
+The HTML is not a markdown render. It is a designed document. Build from the template, not from scratch.
+
+---
+
+## Required structure per finding (HTML)
+
+Every `<section class="finding">` MUST contain, in order:
+
+1. **Header row** — `<h2>` with embedded finding ID, plus `.pill-novel` (purple, for genuinely new evidence) OR `.pill-connected` (outline, for new framings of public facts), plus `.pill-high` / `.pill-med` / `.pill-low` for confidence.
+2. **Deck** — one-line subhed under the H2 in `<p class="deck">` (≤60ch).
+3. **Stats grid** (optional) — `<div class="stats">` for findings with quantitative spine.
+4. **Body paragraphs** — `<p>` (auto-constrained to ≤72ch via column width).
+5. **`<div class="path" aria-label="How we got here">`** — REPLICATION PATH. One `.step` + `.what` pair per phase that produced this finding. Cite scripts, archived URLs, source documents. This block is what makes the finding auditable in under a minute. **Mandatory.**
+6. **`<div class="sources">`** — primary-source URLs with archive references. **Mandatory.**
+
+Optional add-ins:
+- `<div class="flag">` for legal qualifications — use `<span class="flag-label">` for the in-line label, NOT `<strong style="display:block">`.
+- `<div class="timeline">` for chronological evidence chains (2-column grid: date, event).
+- `<div class="pull">` for a 1-2 sentence pull quote inside the finding body.
+
+---
+
+## The `.path` block — Spotlight phase vocabulary
+
+Each `.step` label names the Spotlight phase that produced that step. Standard vocabulary:
+
+- `P1 brief` — what scope was approved
+- `P2 method` — what investigator's planning phase decided
+- `P3 cycle N` — execution cycle N (which detector / search / source was queried)
+- `P3 fact-check` — what the fact-checker added or corrected
+- `P3 archive` — which web sources were archived (firecrawl + Wayback)
+- `P3 social` — when social-media-intelligence is used (account authenticity, coordination)
+- `P3 follow-the-money` — when follow-the-money skill traced financial flows
+- `P4 gate` — what the user iterated at Gate 1
+
+When invoked via **data-detective handover**, also use:
+
+- `P0/P1 upstream` — data-detective ingest + resolve that produced the lead
+- `P3 upstream detect` — data-detective detector name + SQL hash that flagged the lead
+- `P6 handover` — the data-detective spotlight-handoff brief that triggered the Spotlight cycle
+
+Each finding's `.path` block walks the actual trail. Don't invent steps that didn't happen.
+
+---
+
+## Methodology section pattern (highest-leverage learning)
+
+The methodology section serves a dual purpose: it documents the skill (the algorithm) AND it logs the actual run. It is NOT a separate generic methodology. It is the audit trail of THIS investigation, in phase order.
+
+Structure: one `<div class="phase">` per executed phase.
+
+**Critical:** do NOT break the adversarial fact-check verdict table into a separate top-level section. It reads out of phase order. Instead, place it INSIDE the Phase 3 `<div class="phase">`.
+
+When invoked via **data-detective handover**, the methodology section spans BOTH orchestrators:
+
+```
+<div class="phase">P0 upstream · data-detective ingest</div>
+<div class="phase">P1 upstream · data-detective resolve</div>
+<div class="phase">P3 upstream · data-detective detect (which detector flagged the lead)</div>
+<div class="phase">P6 upstream · data-detective spotlight-handoff (the brief)</div>
+<div class="phase">P1 · Spotlight brief (this orchestrator)</div>
+<div class="phase">P2 · Spotlight methodology</div>
+<div class="phase">P3 · Spotlight execution cycles + adversarial fact-check (verdict table INSIDE)</div>
+<div class="phase">P4 · Spotlight Gate 1</div>
+<div class="phase">P5 · Spotlight report-drafting (this document)</div>
+```
+
+Read the case's `data/investigation-log.json` (Spotlight's) and (if hybrid) `case-trace/data-detective/investigation-log.json` (upstream) to enumerate the actual phases executed.
+
+---
+
+## Design discipline
+
+CSS variables already in the template (`--ink`, `--paper`, `--rule`, `--bg-soft`, `--red`, `--mono`, `--sans`, `--serif`). Do not reinvent them per finding.
+
+**Max-width rules** (the template enforces these; do not override per-element):
+- `h1` → 28ch
+- `h2` → 32ch
+- `.deck` (subhed) → 60ch
+- Body `<p>` → constrained by the column, max-width:none
+- `.lede` → constrained by the column, max-width:none
+- Tables / `.stats` / `.path` / `.sources` / `.flag` / `.timeline` / `.phase` → full column width
+
+**Pill semantics:**
+- `.pill-novel` (purple) — genuinely new evidence not previously published.
+- `.pill-connected` (outline) — new framing of public facts via cross-source join.
+- `.pill-verified` (green) — fact-checker confirmed.
+- `.pill-partial` (amber) — fact-checker partial verdict.
+- `.pill-high` / `.pill-med` / `.pill-low` — confidence levels.
+- `.pill-id` (mono, light) — finding ID badge.
+
+**TL;DR table** at the top: one row per finding, `<a href="#f-NNN">` linked, with novelty + confidence pills inline.
+
+---
+
+## HTML editing protocol (hard rule)
+
+NEVER run greedy regex substitution on the HTML file. Use anchored read+edit only. A greedy `re.sub` destroyed a 800-line report mid-pass in a prior investigation and forced a full rebuild.
+
+Specifically:
+- For per-finding additions: anchor the replace pattern on the closing element of the prior block + the opening of the target block.
+- For methodology restructuring: extract the existing section, rewrite as a single block, replace with one edit call.
+- If you must regex, do it in a one-shot Python script that prints the diff first, never `re.sub(..., re.DOTALL)` on the whole file.
+
+---
+
+## Workflow
+
+```
+1. Read references/report-template.html. Copy to cases/{project}/report.html.
+2. Fill the header (title, deck, byline, lede) and the TL;DR table from data/findings.json.
+3. For each verified finding in data/findings.json:
+   a. Drop a <section class="finding"> from the template's finding-stub block.
+   b. Fill the H2 + pills (novelty inferred from finding's origin + corroboration; confidence from fact-check verdict).
+   c. Write the body (3-6 paragraphs, prose).
+   d. Insert the .path block — one .step+.what pair per phase that produced this finding. Cite scripts, archived URLs, source documents.
+   e. Insert the .sources strip — primary-source URLs only (not secondary commentary).
+4. Fill methodology section:
+   a. One .phase block per executed Spotlight phase (P0..P5). If hybrid: also one .phase block per executed upstream data-detective phase.
+   b. INSIDE Phase 3: adversarial fact-check verdict table.
+5. Fill "Open monitoring targets" section from data/findings.json's unresolved-gaps and monitoring_recommendations[].
+6. Fill footer: conflicts of interest, source attributions.
+7. Write findings-report.md in parallel (narrative form, no styling, every claim sourced).
+8. Write evidence-map.json (audit ledger).
+9. Validate HTML tags balance.
+10. Append report_drafted to data/investigation-log.json.
+```
+
+---
+
+## Inputs / Outputs
+
+**Reads:**
+- `cases/{project}/data/findings.json` (verified claims)
+- `cases/{project}/data/fact-check.json` (adversarial verdicts)
+- `cases/{project}/data/investigation-log.json` (phase log)
+- `cases/{project}/data/provenance-manifest.json` (if present)
+- `cases/{project}/summary.md` (Gate 1 artifact)
+- (hybrid) `cases/{project}/data-detective-handover/` (upstream case-trace + briefs)
+
+**Writes:**
+- `cases/{project}/report.html`
+- `cases/{project}/findings-report.md`
+- `cases/{project}/evidence-map.json`
+
+---
+
+## Anti-patterns
+
+- **Wall-of-text findings.** Every finding gets a `.path` block. If you find yourself writing "we cycled through three search rounds, then verified with the fact-checker, then archived" in the prose, lift it out into the path block.
+- **Methodology-at-the-bottom dumping ground.** The methodology section is the run log; phases must appear in phase order, with the fact-check verdict table INSIDE the relevant Phase 3 block.
+- **Sources at the end of the document.** Sources go inline per-finding via `.sources` strip. Readers should never have to scroll to a bibliography.
+- **`.flag strong { display: block }`.** Breaks inline legal citations to new lines. Use `<span class="flag-label">` instead.
+- **Markdown-style HTML.** The HTML is a designed document, not a markdown render. If your HTML reads like a `pandoc` output, restart from the template.
+- **Regex on the live file.** Use anchored read+edit. A greedy substitution will destroy hours of work.
+
+---
+
+## Template
+
+`references/report-template.html` is a working skeleton with:
+- Full CSS variables + classes (.pill-*, .path, .sources, .stats, .flag, .timeline, .phase, .pull, .deck, .tldr)
+- A `<head>` block with the typography stack
+- Header, TL;DR table, finding-stub, methodology stub (with hybrid-mode upstream phase blocks commented in), open-targets stub, footer
+- HTML comments marking the agent customization points
+
+Copy it, fill it, ship it.

--- a/skills/report-drafting/references/report-template.html
+++ b/skills/report-drafting/references/report-template.html
@@ -1,0 +1,385 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{{INVESTIGATION TITLE}} — {{OUTLET}}</title>
+<!--
+  REPORT-DRAFTING TEMPLATE (Phase 5, Spotlight)
+
+  This is a working skeleton. The CSS is production-ready and battle-tested.
+  Customization points are marked with HTML comments and {{PLACEHOLDERS}}.
+
+  AGENT INSTRUCTIONS:
+    1. Copy this file to cases/{project}/report.html.
+    2. Replace {{PLACEHOLDERS}} with investigation-specific content.
+    3. Duplicate the <section class="finding"> block once per verified finding.
+    4. Duplicate the <div class="phase"> block once per executed Spotlight phase.
+       If invoked via data-detective handover, ALSO add one .phase block per
+       upstream data-detective phase that produced the lead.
+    5. Fill .path blocks (mandatory per finding) with archived URLs + source documents.
+       Use Spotlight phase vocabulary in .step labels — see report-drafting SKILL.md.
+    6. Fill .sources strips (mandatory per finding) with primary-source URLs.
+    7. Place the fact-check verdict table INSIDE the Phase 3 .phase block — never
+       as a separate top-level section.
+    8. Do NOT add max-width overrides per element — the template enforces typography.
+    9. Edit with anchored read+edit. Never greedy regex.
+-->
+<style>
+  :root{
+    --ink:#1a1815;--paper:#fbf8f1;--rule:#d4cdc0;--rule-strong:#2a2620;
+    --red:#a8200d;--amber:#9a6800;--green:#3a6e2a;--grey:#6b6258;--mute:#8a7f70;
+    --purple:#5b3a8a;
+    --bg-soft:#f4efe4;--bg-warm:#fbf3df;--bg-green:#eef5e8;--bg-purple:#f0eaf7;
+    --serif:"Iowan Old Style","Charter","Source Serif Pro",ui-serif,Georgia,serif;
+    --sans:"Inter","Helvetica Neue",ui-sans-serif,system-ui,sans-serif;
+    --mono:"JetBrains Mono","SFMono-Regular",ui-monospace,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0;background:var(--paper);color:var(--ink);font-family:var(--serif);font-size:17px;line-height:1.6;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+  a{color:var(--red);text-underline-offset:.18em;text-decoration-thickness:.06em}
+  a:hover{background:rgba(168,32,13,.08)}
+  .wrap{max-width:960px;margin:0 auto;padding:48px 28px 72px}
+
+  /* ───── masthead + hero ───── */
+  .masthead{display:flex;justify-content:space-between;align-items:baseline;border-bottom:1px solid var(--rule-strong);padding-bottom:10px;margin-bottom:36px;font-family:var(--sans);font-size:12px;letter-spacing:.06em;text-transform:uppercase}
+  .masthead .pub{font-weight:700}
+  .masthead .meta{color:var(--grey)}
+  h1{font-family:var(--serif);font-size:44px;line-height:1.1;font-weight:800;margin:0 0 18px;letter-spacing:-.018em;max-width:28ch}
+  .deck{font-size:19px;line-height:1.5;color:#3a342c;margin:0 0 26px;max-width:60ch}
+  .deck em{font-style:italic;color:var(--ink)}
+  .byline{font-family:var(--sans);font-size:12px;color:var(--mute);letter-spacing:.04em;text-transform:uppercase;margin:0 0 36px;line-height:1.7;max-width:80ch}
+  .byline strong{color:var(--ink);font-weight:700;text-transform:none;letter-spacing:0;font-family:var(--sans);font-size:13px}
+  .byline a{color:var(--ink);text-decoration:underline dotted .04em}
+
+  /* honesty box (optional — for limitations / conflicts disclosure up top) */
+  .honesty{background:var(--bg-soft);border:1px solid var(--rule);border-radius:8px;padding:22px 26px;margin:0 0 44px;font-family:var(--sans);font-size:14px;line-height:1.6;max-width:80ch}
+  .honesty .label{display:block;text-transform:uppercase;letter-spacing:.1em;font-size:10px;font-weight:700;color:var(--mute);margin-bottom:12px}
+  .honesty h3{font-family:var(--sans);font-size:13px;font-weight:800;letter-spacing:.04em;text-transform:uppercase;color:var(--ink);margin:14px 0 6px}
+  .honesty h3:first-of-type{margin-top:0}
+  .honesty p{margin:0 0 10px;max-width:none;font-family:var(--sans);font-size:14px}
+  .honesty p:last-child{margin-bottom:0}
+
+  /* ───── TLDR strip ───── */
+  .tldr{display:grid;grid-template-columns:repeat(3,1fr);gap:20px 24px;border-top:1px solid var(--rule-strong);border-bottom:1px solid var(--rule-strong);padding:28px 0;margin:0 0 56px}
+  .tldr-item{display:flex;flex-direction:column;gap:6px}
+  .tldr-num{font-family:var(--mono);font-size:11px;font-weight:700;letter-spacing:.06em;color:var(--mute);display:flex;align-items:center;gap:5px;flex-wrap:wrap}
+  .tldr-claim{font-size:14px;line-height:1.5;color:var(--ink);font-family:var(--sans)}
+  .tldr-item a{color:var(--ink);text-decoration:none}
+  .tldr-item a:hover{text-decoration:underline}
+  .tldr-claim strong{display:block;margin-bottom:3px;color:var(--ink);font-weight:700}
+
+  /* ───── pills + chips ───── */
+  .pill{display:inline-block;padding:2px 8px;border-radius:3px;font-family:var(--sans);font-size:10px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;line-height:1.5;vertical-align:1px}
+  .pill-high{background:var(--green);color:#fff}
+  .pill-med{background:var(--amber);color:#fff}
+  .pill-low{background:var(--mute);color:#fff}
+  .pill-novel{background:var(--purple);color:#fff}
+  .pill-novel::before{content:"✦ "}
+  .pill-connected{background:transparent;border:1px solid var(--mute);color:var(--mute)}
+  .pill-verified{background:var(--bg-green);border:1px solid var(--green);color:var(--green)}
+  .pill-verified::before{content:"✓ "}
+  .pill-partial{background:var(--bg-warm);border:1px solid var(--amber);color:var(--amber)}
+  .pill-partial::before{content:"~ "}
+  .pill-id{background:var(--ink);color:var(--paper);font-family:var(--mono);letter-spacing:.04em}
+
+  /* ───── section headings ───── */
+  h2{font-family:var(--serif);font-size:28px;font-weight:700;letter-spacing:-.012em;margin:18px 0 14px;line-height:1.22;max-width:32ch}
+  h3{font-family:var(--sans);font-size:12px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;color:var(--mute);margin:28px 0 10px}
+  .kicker{font-family:var(--sans);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--red);margin-bottom:6px}
+  .lede{font-size:17px;line-height:1.6;color:#2a2620;margin:0 0 22px;max-width:none}
+  p{margin:0 0 1em;max-width:none}
+
+  /* ───── finding ───── */
+  .finding{border-top:1px solid var(--rule-strong);padding:44px 0 32px}
+  .finding:last-of-type{border-bottom:1px solid var(--rule-strong)}
+  .finding-meta{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:12px}
+  .finding-meta .cat{color:var(--mute);font-size:11px;text-transform:uppercase;letter-spacing:.06em;font-family:var(--sans);margin-left:4px}
+
+  /* stats card row */
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;margin:22px 0;background:var(--rule);border:1px solid var(--rule);border-radius:6px;overflow:hidden}
+  .stats.cols-3{grid-template-columns:repeat(3,1fr)}
+  .stats.cols-5{grid-template-columns:repeat(5,1fr)}
+  .stat{background:var(--bg-soft);padding:14px 16px;display:flex;flex-direction:column}
+  .stat-v{font-family:var(--sans);font-size:22px;font-weight:800;color:var(--ink);letter-spacing:-.015em;line-height:1.1}
+  .stat-l{font-family:var(--sans);font-size:10.5px;color:var(--mute);text-transform:uppercase;letter-spacing:.05em;margin-top:6px;line-height:1.35}
+
+  /* ───── per-claim "how we got here" path (MANDATORY per finding) ───── */
+  .path{display:grid;grid-template-columns:auto 1fr;gap:6px 14px;margin:18px 0;padding:12px 16px;background:var(--bg-soft);border-left:3px solid var(--red);border-radius:0 4px 4px 0;font-family:var(--sans);font-size:13.5px;line-height:1.5}
+  .path .step{font-family:var(--mono);font-size:11px;font-weight:700;color:var(--red);letter-spacing:.04em;white-space:nowrap;padding-top:1px}
+  .path .what{color:var(--ink)}
+  .path .what code{font-family:var(--mono);font-size:12px;background:rgba(0,0,0,.05);padding:1px 5px;border-radius:3px}
+
+  /* ───── methodology phase walkthrough ───── */
+  .phase{margin:26px 0 18px;padding:14px 18px 16px;border:1px solid var(--rule);border-left:4px solid var(--ink);border-radius:0 4px 4px 0;background:#fdfaf2;max-width:none}
+  .phase .phase-head{display:flex;align-items:baseline;gap:14px;margin:0 0 8px;flex-wrap:wrap}
+  .phase .phase-id{font-family:var(--mono);font-weight:800;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--red);background:rgba(168,32,13,.06);padding:3px 8px;border-radius:3px;white-space:nowrap}
+  .phase .phase-title{font-family:var(--sans);font-weight:700;font-size:15.5px;color:var(--ink);margin:0}
+  .phase p{font-family:var(--sans);font-size:13.5px;line-height:1.65;color:var(--ink);margin:6px 0;max-width:none}
+  .phase ul{margin:6px 0 4px;padding-left:20px;font-family:var(--sans);font-size:13.5px;line-height:1.65}
+  .phase ul li{margin:3px 0}
+  .phase code{font-family:var(--mono);font-size:12px;background:rgba(0,0,0,.05);padding:1px 5px;border-radius:3px}
+  .phase table{margin-top:10px}
+
+  /* ───── sources strip (MANDATORY per finding) ───── */
+  .sources{margin:18px 0;padding:11px 16px;background:#fdfaf2;border:1px solid var(--rule);border-left:3px solid var(--ink);border-radius:0 4px 4px 0;font-family:var(--sans);font-size:13px;line-height:1.7}
+  .sources .label{display:inline-block;font-weight:800;letter-spacing:.08em;text-transform:uppercase;font-size:10px;color:var(--mute);margin-right:8px;vertical-align:1px}
+  .sources a{color:var(--ink);text-decoration:underline dotted .04em;text-underline-offset:.18em;margin:0 1px}
+  .sources a::after{content:" ↗";color:var(--mute);font-size:11px}
+  .sources .sep{color:var(--rule);margin:0 4px}
+
+  /* ───── pull quote ───── */
+  .pull{font-family:var(--serif);font-size:20px;line-height:1.4;font-weight:500;color:var(--ink);padding:18px 0;margin:24px 0;border-top:1px solid var(--rule);border-bottom:1px solid var(--rule);font-style:italic}
+  .pull cite{display:block;font-family:var(--sans);font-size:11px;color:var(--mute);font-style:normal;text-transform:uppercase;letter-spacing:.06em;margin-top:8px}
+  .pull cite::before{content:"— "}
+
+  /* ───── details / infobox ───── */
+  details{margin:16px 0;border:1px solid var(--rule);border-radius:6px;background:var(--bg-soft);overflow:hidden}
+  summary{cursor:pointer;padding:11px 16px;font-family:var(--sans);font-weight:700;font-size:12px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink);list-style:none;display:flex;align-items:center;gap:8px}
+  summary::-webkit-details-marker{display:none}
+  summary::before{content:"+";color:var(--red);font-weight:800;font-size:14px;width:14px;display:inline-block}
+  details[open] summary::before{content:"−"}
+  details[open]{background:#fdfaf2}
+  details > div{padding:0 18px 16px;font-size:14.5px;line-height:1.6}
+  details > div p{font-size:14.5px;max-width:80ch}
+
+  /* ───── tables ───── */
+  table{border-collapse:collapse;width:100%;font-size:13.5px;font-family:var(--sans);margin:8px 0 16px}
+  th,td{border-bottom:1px solid var(--rule);padding:9px 10px;text-align:left;vertical-align:top;line-height:1.45}
+  th{font-weight:700;background:transparent;letter-spacing:.05em;text-transform:uppercase;font-size:10px;color:var(--mute);border-bottom:1.5px solid var(--rule-strong)}
+  td.num{font-variant-numeric:tabular-nums;font-family:var(--mono);font-size:12.5px;text-align:right}
+  td code{font-family:var(--mono);font-size:11.5px;background:var(--bg-soft);padding:1px 5px;border-radius:3px}
+
+  /* ───── legal flag (USE .flag-label, NEVER inline <strong style="display:block">) ───── */
+  .flag{background:var(--bg-warm);border:1px solid #e6d4a8;border-left:3px solid var(--amber);padding:14px 18px;margin:20px 0;border-radius:0 4px 4px 0}
+  .flag .flag-label{display:block;font-family:var(--sans);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--amber);margin-bottom:6px;font-weight:800}
+  .flag p{margin:0;max-width:none;font-size:14.5px;line-height:1.55}
+  .flag p code{font-family:var(--mono);font-size:12.5px;background:rgba(154,104,0,.1);padding:1px 5px;border-radius:3px;font-weight:700;color:var(--amber)}
+
+  /* ───── timeline ───── */
+  .timeline{display:grid;grid-template-columns:auto 1fr;gap:6px 16px;margin:18px 0;font-family:var(--sans);font-size:14px}
+  .timeline .date{font-weight:800;color:var(--red);font-family:var(--mono);font-size:13px;white-space:nowrap}
+  .timeline .event{color:var(--ink);line-height:1.5}
+
+  /* ───── footer ───── */
+  footer{border-top:1px solid var(--rule-strong);margin-top:64px;padding-top:24px;font-family:var(--sans);font-size:13px;color:var(--mute);line-height:1.65;max-width:80ch}
+  footer a{color:var(--ink)}
+  footer p{max-width:none;font-size:13px}
+  footer .databases{margin-top:14px;display:flex;flex-wrap:wrap;gap:6px 4px}
+  footer .databases span{display:inline-block;border:1px solid var(--rule);padding:2px 8px;border-radius:3px;font-size:11px;background:var(--bg-soft);color:var(--ink)}
+
+  /* ───── mobile ───── */
+  @media (max-width:820px){
+    .wrap{padding:28px 18px}
+    h1{font-size:30px;max-width:none}
+    .deck{font-size:16px}
+    .tldr{grid-template-columns:1fr}
+    .stats{grid-template-columns:repeat(2,1fr)}
+    .stats.cols-3,.stats.cols-5{grid-template-columns:repeat(2,1fr)}
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- ════════════════════════ MASTHEAD + HERO ════════════════════════ -->
+  <div class="masthead">
+    <span class="pub">{{OUTLET}}</span>
+    <span class="meta">{{INVESTIGATION SLUG}} · {{DATE}}</span>
+  </div>
+
+  <h1>{{HEADLINE — one-sentence claim, ≤28ch wide}}</h1>
+  <p class="deck">{{SUBHED — what the investigation found, in one line, ≤60ch wide}}</p>
+
+  <p class="byline">
+    <strong>By {{AUTHOR}}</strong> · {{ORGANIZATION}} · <a href="mailto:{{EMAIL}}">{{EMAIL}}</a><br>
+    {{COMMIT_HASH}} · {{N}} verified findings · {{M}} primary-source citations
+  </p>
+
+  <!-- ════════════════════════ TL;DR STRIP ════════════════════════ -->
+  <section class="tldr" aria-label="findings summary">
+    <!-- Duplicate .tldr-item per finding. Link to anchor. Inline pills. -->
+    <div class="tldr-item">
+      <div class="tldr-num">F-001 <span class="pill pill-novel">novel</span> <span class="pill pill-high">high</span></div>
+      <div class="tldr-claim"><a href="#f-001"><strong>{{Finding 1 one-line claim}}</strong>{{1-sentence detail}}</a></div>
+    </div>
+    <!-- ... more tldr items ... -->
+  </section>
+
+  <!-- ════════════════════════ FINDINGS ════════════════════════ -->
+
+  <!--
+    FINDING TEMPLATE — duplicate per verified finding.
+    Required elements (in order):
+      1. <div class="finding-meta"> with pill-id + pill-novel|connected + pill-high|med|low + cat
+      2. <h2> with one-sentence claim
+      3. body paragraphs (3-6, prose)
+      4. <div class="stats"> if quantitative
+      5. <div class="path"> MANDATORY — replication trail
+      6. <div class="sources"> MANDATORY — primary-source URLs
+      7. <div class="flag"> if legal qualification needed
+  -->
+  <section class="finding" id="f-NNN">
+    <div class="finding-meta">
+      <span class="pill pill-id">F-NNN</span>
+      <span class="pill pill-novel">novel</span> <!-- or pill-connected -->
+      <span class="pill pill-high">high</span> <!-- or pill-med / pill-low -->
+      <span class="cat">{{category, e.g. "Lobbying · LDA"}}</span>
+    </div>
+
+    <h2>{{Finding claim — one sentence, ≤32ch wide}}</h2>
+
+    <p class="lede">{{Lede — 1-2 sentences that frame the finding for a reader who only reads the first paragraph.}}</p>
+
+    <p>{{Body paragraph 1 — context, prior reporting, why this is new.}}</p>
+    <p>{{Body paragraph 2 — the evidence, with inline citations to filings / records.}}</p>
+    <p>{{Body paragraph 3 — the so-what / why it matters.}}</p>
+
+    <!-- Optional: quantitative spine -->
+    <div class="stats cols-3">
+      <div class="stat"><span class="stat-v">{{$N.NM}}</span><span class="stat-l">{{Metric 1}}</span></div>
+      <div class="stat"><span class="stat-v">{{N}}</span><span class="stat-l">{{Metric 2}}</span></div>
+      <div class="stat"><span class="stat-v">{{N×}}</span><span class="stat-l">{{Metric 3}}</span></div>
+    </div>
+
+    <!-- MANDATORY: replication path. .step labels use Spotlight phase vocabulary.
+         If invoked via data-detective handover, prefix upstream steps with "P*upstream". -->
+    <div class="path" aria-label="How we got here">
+      <!-- HYBRID (data-detective handover) — uncomment if applicable:
+      <div class="step">P3 upstream detect</div><div class="what">{{data-detective detector + SQL hash that flagged the lead}}</div>
+      <div class="step">P6 upstream handover</div><div class="what">{{data-detective spotlight-handoff brief that triggered this Spotlight cycle}}</div>
+      -->
+      <div class="step">P1 brief</div><div class="what">{{What scope the user approved}}</div>
+      <div class="step">P2 method</div><div class="what">{{What the investigator's planning phase decided to pursue}}</div>
+      <div class="step">P3 cycle 1</div><div class="what">{{Which detector / search / source was queried}}</div>
+      <div class="step">P3 archive</div><div class="what">{{firecrawl + Wayback URLs archived for this claim}}</div>
+      <div class="step">P3 fact-check</div><div class="what">{{What the fact-checker added or corrected}}</div>
+    </div>
+
+    <!-- Optional: legal flag -->
+    <div class="flag">
+      <span class="flag-label">Legal qualification</span>
+      <p>{{Specific statutory citation in <code>2 U.S.C. § 1602(8)</code> form, what is alleged, what is not.}}</p>
+    </div>
+
+    <!-- MANDATORY: sources strip -->
+    <div class="sources">
+      <span class="label">Sources</span>
+      <a href="{{URL}}">{{Primary source 1}}</a>
+      <span class="sep">·</span>
+      <a href="{{URL}}">{{Primary source 2}}</a>
+      <span class="sep">·</span>
+      <a href="{{URL}}">{{Archive.org snapshot}}</a>
+    </div>
+  </section>
+
+  <!-- ... more findings ... -->
+
+  <!-- ════════════════════════ METHODOLOGY (FULL RUN) ════════════════════════ -->
+
+  <!--
+    METHODOLOGY PATTERN (critical):
+    - This section serves a dual purpose: it documents the skill AND logs the run.
+    - One <div class="phase"> per executed phase, in phase order.
+    - DO NOT break adversarial fact-check and spotlight-handoff into separate
+      top-level sections — they read out of phase order. Place them INSIDE
+      the relevant phase block (P3 and P6 respectively).
+  -->
+  <section id="method">
+    <div class="kicker">Methodology · how the full run was executed</div>
+    <h2 style="margin-top:36px">How <code style="font-size:.7em;background:var(--bg-soft);padding:2px 8px;border-radius:4px">spotlight</code> works — phase by phase.</h2>
+
+    <p class="lede">{{2-3 sentence framing — what scope the investigation covered, what it produced.}}</p>
+
+    <!-- ════════ HYBRID MODE (data-detective handover) ════════
+         If invoked via data-detective handover, uncomment this block and fill from the
+         upstream case-trace at cases/{project}/data-detective-handover/.
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Upstream · data-detective P0/P1 ingest</span><h4 class="phase-title">{{What ingest produced upstream}}</h4></div>
+      <p>{{What was loaded, table counts, the detector that flagged the lead.}}</p>
+    </div>
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Upstream · data-detective P3 detect</span><h4 class="phase-title">{{Detector name + SQL hash}}</h4></div>
+      <p>{{What surfaced, why it warranted external OSINT amplification.}}</p>
+    </div>
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Upstream · data-detective P6 handover</span><h4 class="phase-title">spotlight-handoff brief OS-NNN</h4></div>
+      <p>{{The brief that triggered this Spotlight investigation.}}</p>
+    </div>
+    -->
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Phase 0 · preflight</span><h4 class="phase-title">Project setup, search-library detection, vault config.</h4></div>
+      <p>{{Search library used, vault path, integrations enabled.}}</p>
+    </div>
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Phase 1 · brief</span><h4 class="phase-title">Scope approved by user.</h4></div>
+      <p>{{The lead as restated, what was in scope, what was out.}}</p>
+    </div>
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Phase 2 · methodology</span><h4 class="phase-title">Investigator planned the investigation.</h4></div>
+      <p>{{Threads to pursue, sources to consult, OSINT angles. From data/methodology.json.}}</p>
+    </div>
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Phase 3 · execution cycles + fact-check</span><h4 class="phase-title">Investigator + fact-checker autonomous loop.</h4></div>
+      <p>{{N cycles, M tool calls, K sources archived. Per-cycle gap-eval that drove additional cycles.}}</p>
+
+      <p><strong>Key sources surfaced:</strong></p>
+      <ul>
+        <li>{{Primary document or OSINT discovery}}.</li>
+      </ul>
+
+      <!-- ADVERSARIAL FACT-CHECK VERDICTS — INSIDE PHASE 3, NOT SEPARATE -->
+      <p><strong>Adversarial fact-check verdicts</strong> (independent fact-checker):</p>
+      <table>
+        <tr><th>Claim</th><th>Verdict</th><th>Key fact-checker contribution</th></tr>
+        <tr><td>F-NNN</td><td><strong>verified · high</strong></td><td>{{What the fact-checker added or corrected.}}</td></tr>
+      </table>
+    </div>
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Phase 4 · Gate 1</span><h4 class="phase-title">Human-readable summary, user-approval checkpoint.</h4></div>
+      <p>{{summary.md written; review.html generated for editorial feedback; iteration that happened at the gate.}}</p>
+    </div>
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Phase 5 · report-drafting</span><h4 class="phase-title">This document.</h4></div>
+      <p>report.html + findings-report.md + evidence-map.json produced from the verified Phase 3 output.</p>
+    </div>
+
+    <div class="phase">
+      <div class="phase-head"><span class="phase-id">Phase 6 · ingest</span><h4 class="phase-title">Knowledge-base archival.</h4></div>
+      <p>{{N finding notes, N entity notes written to the vault.}}</p>
+    </div>
+  </section>
+
+  <!-- ════════════════════════ OPEN MONITORING TARGETS ════════════════════════ -->
+  <section id="next">
+    <div class="kicker">Open monitoring targets</div>
+    <h2 style="margin-top:36px">What the next cycle should close.</h2>
+    <table>
+      <tr><th>Target</th><th>Why</th></tr>
+      <tr><td><strong>{{Target}}</strong></td><td>{{Why this matters next cycle.}}</td></tr>
+    </table>
+  </section>
+
+  <!-- ════════════════════════ FOOTER ════════════════════════ -->
+  <footer>
+    <p><strong>Submission contents</strong> at <code>submission/</code>: {{enumerate deliverables}}.</p>
+    <p><strong>Conflicts of interest:</strong> {{disclosure or "None."}}</p>
+    <p class="databases">
+      <span>{{database 1}}</span>
+      <span>{{database 2}}</span>
+      <!-- one chip per data source touched -->
+    </p>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/skills/spotlight/SKILL.md
+++ b/skills/spotlight/SKILL.md
@@ -488,7 +488,7 @@ After approval, `invoke-skill("review")` to produce `cases/{project}/review.html
 
 Offer the user:
 
-> "Review artifact written to `cases/{project}/review.html`. Open it in any browser to inspect findings and submit feedback (optional). If you submit feedback, save the exported `review-feedback.json` into `cases/{project}/data/` and re-run `/spotlight` to process it. Or proceed to ingestion now."
+> "Review artifact written to `cases/{project}/review.html`. Open it in any browser to inspect findings and submit feedback (optional). If you submit feedback, save the exported `review-feedback.json` into `cases/{project}/data/` and re-run `/spotlight` to process it. Or proceed to drafting the public report now."
 
 ### Feedback processing (on resume)
 
@@ -496,9 +496,25 @@ When `/spotlight` is resumed and `cases/{project}/data/review-feedback.json` exi
 
 ---
 
-## Phase 5 — Ingestion
+## Phase 5 — Report drafting (public-facing)
 
-After Gate 1 approval:
+After Gate 1 approval, offer the user the public-facing report:
+
+> "Draft the public-facing journalist-grade report now?
+> (a) Yes — invoke report-drafting to produce report.html + findings-report.md + evidence-map.json.
+> (b) No — skip to ingestion. (`review.html` already covers editorial review.)"
+
+If (a): `invoke-skill("report-drafting")` — produces `cases/{project}/report.html` (designed deliverable), `findings-report.md` (narrative audit), and `evidence-map.json` (machine-readable ledger). See `skills/report-drafting/SKILL.md`.
+
+### Hybrid mode (data-detective handover)
+
+When `cases/{project}/data-detective-handover/` exists (i.e. this Spotlight run was triggered by a data-detective formal handover, not a standalone lead), `report-drafting` runs in hybrid mode: the methodology section spans both orchestrators in phase order — upstream data-detective phases (P0/P1 ingest, P3 detect, P6 handover) followed by Spotlight phases (P1 brief, P2 method, P3 cycles + fact-check, P4 Gate 1, P5 report-drafting). Each finding's `.path` block walks the actual trail from upstream detector to downstream fact-checker. Skip the offer above — drafting is the whole point of the handover. Invoke `report-drafting` automatically.
+
+---
+
+## Phase 6 — Ingestion
+
+After report drafting (or after Gate 1 if drafting was skipped):
 
 > "Investigation complete. Ingest confirmed findings into your knowledge base?"
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -9,7 +9,7 @@
 #   5. Monitoring registry helper runs cleanly
 #   6. No banned Claude-specific syntax in skills/agents
 #   7. No legacy local feed framework remains
-#   8. AGENTS.md has 15 entries in skill registry
+#   8. AGENTS.md has 16 entries in skill registry
 #   9. setup.html exists
 #  10. index.html exists
 #  11. DISCLAIMER.md + LICENSE present
@@ -31,7 +31,7 @@ cd "$ROOT"
 
 echo "── Structure ──"
 
-expected_skills=(spotlight review integrations ingest monitoring provenance-signing acquisition-graduation web-archiving content-access epistemic-grounding shell-safety osint investigate follow-the-money social-media-intelligence)
+expected_skills=(spotlight review integrations ingest report-drafting monitoring provenance-signing acquisition-graduation web-archiving content-access epistemic-grounding shell-safety osint investigate follow-the-money social-media-intelligence)
 for skill in "${expected_skills[@]}"; do
   if [ -f "skills/$skill/SKILL.md" ]; then
     ok "skills/$skill/SKILL.md present"
@@ -99,10 +99,10 @@ fi
 echo ""
 echo "── Contracts ──"
 skill_count=$(grep -cE '^\| `[a-z-]+` \| `skills/' AGENTS.md || echo 0)
-if [ "$skill_count" = "15" ]; then
-  ok "AGENTS.md skill registry has 15 entries"
+if [ "$skill_count" = "16" ]; then
+  ok "AGENTS.md skill registry has 16 entries"
 else
-  fail "AGENTS.md skill registry count off: got $skill_count, want 15"
+  fail "AGENTS.md skill registry count off: got $skill_count, want 16"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

The earlier `SYSTEM "/no_think"` Modelfile directive (PR #29) didn't
work in practice — opencode sends its own system message which
overrides the Modelfile's. Real installs would get empty content.

Two-part fix:

1. **TEMPLATE override in Modelfile** — inject `/no_think` at the
   start of every user message during chat rendering. Survives
   request-level system messages because rendering is rewritten,
   not conversation content.

2. **opencode `limit.output: 16384`** — per-model output cap so
   requests carry enough max_tokens for Qwen's ~10k reasoning
   + ~5k content footprint. Without this, opencode's default
   truncates inside the reasoning phase.

Both pieces written by `install-spotlight.sh` automatically when
`SPOTLIGHT_LOCAL_MODEL=qwen27b`.

## Verification

End-to-end test: real bench prompt (Delaware shell-company beneficial-
ownership tracing) → `spotlight-qwen27b` alias (built as installer
does) → opencode-shaped system+user messages → **6868 chars of
substantive OSINT methodology returned, `finish_reason: stop`, not
truncated.**

Prior broken state (same code path, `SYSTEM "/no_think"` only):
content empty, reasoning hit max_tokens=100, `finish_reason: length`.

## Test plan

- [ ] Reviewer confirms the TEMPLATE Modelfile syntax matches Qwen's
      chat format expectations.
- [ ] Reviewer confirms `limit.output: 16384` is the right
      opencode-side knob (per the [opencode config docs](https://opencode.ai/docs/config/#models)).
- [ ] On a 32 GB Mac: full install with qwen27b selected, confirm
      first opencode chat returns non-empty content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)