### PR TITLE
fix(qwen27b/ollama): add PARAMETER stop for <|im_end|> + <|endoftext|>

### DIFF
--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -385,6 +385,21 @@ if [ "$SPOTLIGHT_MODE" = "local" ]; then
       # We keep the model's native chat template (thinking on) and
       # rely on opencode's `limit.output: 16384` to give enough budget
       # for reasoning + content. Expect ~3-5× slower per-prompt vs 9B.
+      #
+      # Stop-token workaround: the abliterated journalist fine-tune emits
+      # <|endoftext|> at the end of assistant turns rather than the
+      # chat-template's <|im_end|>. Ollama's auto-derived stop list reads
+      # tokenizer.ggml.eos_token_id from the GGUF (= <|im_end|>) and does
+      # NOT include <|endoftext|>, so without these explicit stops the
+      # model rambles past its own end-of-turn into a fake user message.
+      # Adding both is belt-and-braces (verified: finish_reason flips
+      # from "length" to "stop" with these in place).
+      case "$SPOTLIGHT_LOCAL_MODEL" in
+        qwen27b)
+          printf 'PARAMETER stop "<|im_end|>"\n' >> "$TMP_MODELFILE"
+          printf 'PARAMETER stop "<|endoftext|>"\n' >> "$TMP_MODELFILE"
+          ;;
+      esac
       ollama create "$SPOTLIGHT_OLLAMA_ALIAS" -f "$TMP_MODELFILE"
       rm -f "$TMP_MODELFILE"
     elif [ "$DRY_RUN" = "1" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #31. The 27B GGUF on HF (`tomvaillant/qwen3.6-27b-abliterated-journalist-GGUF`) has been re-exported with `chat_template` embedded (via a fix in `scripts/qwen3.6-27b/gguf.py` that inlines `chat_template.jinja` into `tokenizer_config.json` before `convert_hf_to_gguf.py` runs). Ollama now applies the template correctly — but a second bug surfaces underneath: the fine-tune emits `<|endoftext|>` at end-of-turn instead of the template's `<|im_end|>`, and Ollama's auto-derived stop list only includes the latter, so the model rambles past its own stop into a fake user turn.

This PR adds explicit `PARAMETER stop \"<|im_end|>\"` and `PARAMETER stop \"<|endoftext|>\"` to the Modelfile for the `qwen27b` Ollama branch.

## Verification (laptop, against the freshly re-uploaded GGUF)

**Before** (template-only, no explicit stops):
\`\`\`
content: '\n\n<think>\n\n</think>\n\nPONG<|endoftext|><|im_start|>user\nWhat is the capital of France?\n</think>\n\nParis.\n\n'
finish_reason: length
\`\`\`

**After** (template + both stops):
\`\`\`
content: '\n\n<think>\n\n</think>\n\nPONG'
finish_reason: stop
\`\`\`

## Out of scope for this PR

The 9B HF GGUF (\`tomvaillant/qwen3.5-9b-abliterated-journalist-GGUF\`) still ships without an embedded \`chat_template\` — its Ollama path produces malformed output (no template applied at all). That needs its own re-export before its Ollama branch becomes usable. Tracking separately.

## Test plan
- [x] \`bash tests/install-spotlight-smoke.sh\` — 5 passed
- [x] \`node tests/setup-generator-check.js\` — 13 passed
- [x] Real Ollama chat completion against the new GGUF returns clean PONG + finish_reason=stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)