### PR TITLE
fix(qwen9b/ollama): extend PARAMETER stop fix to 9B branch too

### DIFF
--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -395,7 +395,10 @@ if [ "$SPOTLIGHT_MODE" = "local" ]; then
       # Adding both is belt-and-braces (verified: finish_reason flips
       # from "length" to "stop" with these in place).
       case "$SPOTLIGHT_LOCAL_MODEL" in
-        qwen27b)
+        qwen9b|qwen27b)
+          # Both abliterated journalist tunes share the same stop-token bug
+          # class (same training corpus, same Qwen 3.x family). Apply
+          # defensively to both — harmless overhead if not triggered.
           printf 'PARAMETER stop "<|im_end|>"\n' >> "$TMP_MODELFILE"
           printf 'PARAMETER stop "<|endoftext|>"\n' >> "$TMP_MODELFILE"
           ;;


### PR DESCRIPTION
## Summary

After re-exporting the 9B GGUF with two upstream fixes:
1. \`chat_template\` embedded (same inline-into-tokenizer_config pre-conversion as the 27B PR #32)
2. \`--no-mtp\` passed to \`convert_hf_to_gguf.py\` to exclude the MTP head (Ollama's \`qwen3next\` handler crashed with \"layer 32 missing attn_qkv/attn_gate projections\" when the MTP layer was present)

…the 9B now loads cleanly in Ollama and applies the chat template, but it inherits the same stop-token bug as the 27B: emits \`<|endoftext|>\` at end-of-turn rather than the chat-template's \`<|im_end|>\`, and Ollama doesn't stop on the former. Without explicit \`PARAMETER stop\` it rambles past its own stop into \`<|im_start|>\` repetitions.

This PR extends the \`case\` in install-spotlight.sh from \`qwen27b\` to \`qwen9b|qwen27b\` so both tunes get the defensive stop tokens.

## Verification (laptop, against the freshly re-uploaded 9B)

**Baseline** (no PARAMETER stop):
\`\`\`
content: '\n\nPONG<|endoftext|><|im_start|>\n<|im_start|>\n<|im_start|>\n…' x16
finish_reason: stop
\`\`\`

**After** (template + both stops):
\`\`\`
content: '\n\nPONG'
finish_reason: stop
\`\`\`

## Verifier wins

The follow-up validator (kit/claude/fine-tuning/validate_gguf_pipeline.py) catches this class of bug now:
- block_count check flags the MTP regression on Qwen 3.5/3.6 GGUFs
- postflight with --ollama-probe surfaces the stop-token mismatch in finish_reason
- preflight blocks pod allocation if the merged repo's chat_template is unreachable

## Test plan
- [x] \`bash tests/install-spotlight-smoke.sh\` — 5 passed
- [x] \`node tests/setup-generator-check.js\` — 13 passed
- [x] Real Ollama chat completion against the new 9B returns clean PONG + finish_reason=stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)