### PR TITLE
docs: README hero header + expanded acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
+<div align="center">
+
 # Spotlight
+
+### OSINT investigation orchestrator for AI agents
+
+**Turns a lead into a structured case file — scoped brief, approved methodology, sourced findings, independent fact-checking, and provenance records. 16 skills, 7 runtimes, local-capable.**
+
+[Install](#install) | [Workflow](#investigation-workflow) | [Integrations](#integrations) | [Runtimes](#runtimes) | [Website](https://spotlight.buriedsignals.com/)
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-00c853?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)[![16 Skills](https://img.shields.io/badge/skills-16-0080ff?style=for-the-badge&logo=bookstack&logoColor=white)](https://github.com/buriedsignals/spotlight/tree/main/plugins/spotlight/skills)[![7 Runtimes](https://img.shields.io/badge/runtimes-7-aa00ff?style=for-the-badge&logo=windowsterminal&logoColor=white)](#runtimes)[![Sovereign](https://img.shields.io/badge/sovereign_mode-SearXNG_+_Crawl4AI_+_local_models-00bfa5?style=for-the-badge&logo=shield&logoColor=white)](#source-acquisition)
+
+[![Stars](https://img.shields.io/github/stars/buriedsignals/spotlight?style=flat-square&logo=github&label=Stars)](https://github.com/buriedsignals/spotlight/stargazers)[![Issues](https://img.shields.io/github/issues/buriedsignals/spotlight?style=flat-square&logo=github&label=Issues)](https://github.com/buriedsignals/spotlight/issues)[![Last Commit](https://img.shields.io/github/last-commit/buriedsignals/spotlight?style=flat-square&logo=github&label=Last%20Commit)](https://github.com/buriedsignals/spotlight/commits)[![Contributors](https://img.shields.io/github/contributors/buriedsignals/spotlight?style=flat-square&logo=github&label=Contributors)](https://github.com/buriedsignals/spotlight/graphs/contributors)
+
+Built by [**Buried Signals**](https://buriedsignals.com/) • [tom@buriedsignals.com](mailto:tom@buriedsignals.com)
+
+</div>
+
+---
 
 Spotlight turns an investigation lead into a structured case file: scoped brief,
 approved methodology, sourced findings, independent fact-checking, review
@@ -232,6 +250,26 @@ policy. Runtime docs should carry model notes and fit checks.
 - Follow the Money synthesizes public investigative-finance methodology from
   Jim Shultz, GIJN, EBU, and related training material.
 - Investigate includes methodology influenced by Bellingcat training material.
+
+## Acknowledgements
+
+Spotlight stands on open work — community-maintained open-source projects and
+open methods. A sincere thank-you to every project below — Spotlight would not
+exist without them. *(Listing does not imply affiliation or endorsement.)*
+
+| Category | Projects we're grateful to |
+|----------|----------------------------|
+| **Loop harness** | [pi](https://pi.dev/) (Mario Zechner, MIT — the loop-harness coding agent) · [Flue](https://github.com/withastro/flue) (Apache-2.0 — the harness runtime) |
+| **Sovereign search & scraping** | [SearXNG](https://github.com/searxng/searxng) (AGPL-3.0) · [Crawl4AI](https://github.com/unclecode/crawl4ai) (unclecode, Apache-2.0) · [Playwright](https://playwright.dev/) (browser automation) · [Poppler](https://poppler.freedesktop.org/) (`pdftotext` — PDF extraction) · [Tor](https://www.torproject.org/) (opt-in anonymous fetching) |
+| **Local inference** | [llama.cpp](https://github.com/ggml-org/llama.cpp) (ggml, MIT) · [Unsloth](https://unsloth.ai/) (GGUF quants of the local operator model) |
+| **OSINT tooling** | [Maigret](https://github.com/soxoj/maigret) (soxoj, MIT) · [Sherlock](https://github.com/sherlock-project/sherlock) (MIT) · [Holehe](https://github.com/megadose/holehe) (GPL-3.0) · [ExifTool](https://exiftool.org/) (Phil Harvey) · [Unpaywall](https://unpaywall.org/) (OurResearch — open-access paper lookup) |
+| **Evidence & provenance** | [Internet Archive / Wayback Machine](https://web.archive.org/) · [Archive.today](https://archive.today/) · [C2PA](https://c2pa.org/) (content-provenance standard for case packages) · [OpenSanctions](https://www.opensanctions.org/) (evidence-preservation methodology) |
+| **Knowledge vault** | [Obsidian](https://obsidian.md/) (the vault app) · [QMD](https://www.npmjs.com/package/@tobilu/qmd) (tobilu — local vault search) |
+| **Reports & site** | [Mermaid](https://github.com/mermaid-js/mermaid) (MIT — report diagrams) · [Three.js](https://github.com/mrdoob/three.js) (mrdoob, MIT — the landing scene) |
+| **Methodology** | [Joe Amditis](https://github.com/jamditis/claude-skills-journalism) (MIT) · [SIFT — Mike Caulfield](https://hapgood.us/2019/06/19/sift-the-four-moves/) · [Bellingcat](https://www.bellingcat.com/) · [GIJN](https://gijn.org/) (Patrucic & Cosic, CC BY-ND) · Jim Shultz — Follow the Money · [Derek Bowler · EBU](https://www.ebu.ch/) |
+
+> Built something here we should credit, or want a listing changed or removed?
+> Open an issue or PR — we'll fix it fast.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -1787,7 +1787,25 @@
     <li><a href="https://gijn.org/" target="_blank" rel="noopener">GIJN</a> — Patrucic &amp; Cosic, Following the Money · CC BY-ND</li>
     <li>Jim Shultz — Follow the Money</li>
     <li><a href="https://www.ebu.ch/" target="_blank" rel="noopener">Derek Bowler · EBU</a> — beneficial-ownership tracing</li>
+    <li><a href="https://www.opensanctions.org/" target="_blank" rel="noopener">OpenSanctions</a> — evidence-preservation methodology</li>
     <li><a href="https://www.npmjs.com/package/@tobilu/qmd" target="_blank" rel="noopener">QMD</a> — tobilu · local vault search</li>
+    <li><a href="https://pi.dev/" target="_blank" rel="noopener">pi</a> — Mario Zechner · the loop-harness coding agent · MIT</li>
+    <li><a href="https://github.com/withastro/flue" target="_blank" rel="noopener">Flue</a> — the harness runtime · Apache-2.0</li>
+    <li><a href="https://github.com/searxng/searxng" target="_blank" rel="noopener">SearXNG</a> — self-hosted search behind sovereign mode · AGPL</li>
+    <li><a href="https://github.com/unclecode/crawl4ai" target="_blank" rel="noopener">Crawl4AI</a> — unclecode · the sovereign scraper</li>
+    <li><a href="https://playwright.dev/" target="_blank" rel="noopener">Playwright</a> — browser automation under the scraper</li>
+    <li><a href="https://poppler.freedesktop.org/" target="_blank" rel="noopener">Poppler</a> — pdftotext · PDF extraction</li>
+    <li><a href="https://github.com/ggml-org/llama.cpp" target="_blank" rel="noopener">llama.cpp</a> — ggml · local inference</li>
+    <li><a href="https://unsloth.ai/" target="_blank" rel="noopener">Unsloth</a> — GGUF quants of the local operator model</li>
+    <li><a href="https://www.torproject.org/" target="_blank" rel="noopener">Tor Project</a> — opt-in anonymous fetching</li>
+    <li><a href="https://github.com/soxoj/maigret" target="_blank" rel="noopener">Maigret</a> — soxoj · username-led account discovery</li>
+    <li><a href="https://unpaywall.org/" target="_blank" rel="noopener">Unpaywall</a> — OurResearch · open-access paper lookup</li>
+    <li><a href="https://web.archive.org/" target="_blank" rel="noopener">Internet Archive</a> — Wayback Machine · evidence archiving</li>
+    <li><a href="https://archive.today/" target="_blank" rel="noopener">Archive.today</a> — second-tier evidence archiving</li>
+    <li><a href="https://c2pa.org/" target="_blank" rel="noopener">C2PA</a> — content-provenance standard for case packages</li>
+    <li><a href="https://obsidian.md/" target="_blank" rel="noopener">Obsidian</a> — the knowledge vault</li>
+    <li><a href="https://github.com/mermaid-js/mermaid" target="_blank" rel="noopener">Mermaid</a> — diagrams in findings reports</li>
+    <li><a href="https://github.com/mrdoob/three.js" target="_blank" rel="noopener">Three.js</a> — mrdoob · this landing scene</li>
   </ul>
 </section>
 

--- a/setup.html
+++ b/setup.html
@@ -725,7 +725,7 @@
         <div class="item" data-reveal="body" style="--rs: 0">
           <p class="knum"><em>01</em> Required</p>
           <h3>Two keys<em>.</em><span class="badge req">required</span></h3>
-          <p><strong>Firecrawl</strong> powers all web scraping and search — the only permitted web-fetch tool in Spotlight. Free tier available. <strong>OSINT Navigator</strong> is a live database of 10,000+ OSINT tools with AI-powered lookup — essential for country-specific registries and niche techniques.</p>
+          <p>Scraping and search run on self-hosted <strong>SearXNG</strong> + <strong>Crawl4AI</strong> by default; a <strong>Firecrawl</strong> key adds the hosted fallback for hard-to-reach pages. Free tier available. <strong>OSINT Navigator</strong> is a live database of 10,000+ OSINT tools with AI-powered lookup — essential for country-specific registries and niche techniques.</p>
           <div class="item-links">
             <a class="mini-link" href="https://www.firecrawl.dev/" target="_blank" rel="noopener">Firecrawl key →</a>
             <a class="mini-link" href="https://navigator.indicator.media/" target="_blank" rel="noopener">Navigator key →</a>


### PR DESCRIPTION
## What

- **README**: centered hero header (tagline, nav links, shields.io badges — MIT license, 16 skills, 7 runtimes, sovereign mode, plus live GitHub stats) and a categorized acknowledgements table under Attribution.
- **index.html**: acknowledgements section grows from 7 to 24 entries — adds pi (Mario Zechner), Flue, SearXNG, Crawl4AI, Playwright, Poppler, llama.cpp, Unsloth, Tor, Maigret, Unpaywall, Internet Archive, Archive.today, C2PA, Obsidian, Mermaid, Three.js, and OpenSanctions, matching the existing list style.
- **setup.html**: fixes the stale claim that Firecrawl "powers all web scraping and search" — the default is now SearXNG + Crawl4AI, with Firecrawl as the hosted fallback.

## Why

The site credited methodology sources but none of the OSS backbone — the loop harness (pi/Flue), the sovereign scrape stack, or the archive tooling. Scope is limited to community-maintained, operationally load-bearing projects; commercial services and framework plumbing are deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)