### PR TITLE
fix(spotlight): retire configurator fallback

### DIFF
--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -147,8 +147,10 @@ else
     echo "→ Opening the Spotlight configurator in your browser."
     echo "  Your choices and API keys go to a local server on 127.0.0.1 only and are"
     echo "  staged in $SPOTLIGHT_PROFILE_DIR — nothing is uploaded anywhere."
+    ENGINE_PLAN_MARKER="$SPOTLIGHT_PROFILE_DIR/engine-plan.ready"
+    rm -f "$ENGINE_PLAN_MARKER"
     python3 "$CONFIGURATOR_DIR/install/setup_server.py" --profile-dir "$SPOTLIGHT_PROFILE_DIR" --repo-dir "$CONFIGURATOR_DIR"
-    if [ -f "$SPOTLIGHT_PROFILE_DIR/engine-plan.ready" ]; then
+    if [ -f "$ENGINE_PLAN_MARKER" ]; then
       printf '✓ Engine wrote a sealed Spotlight plan. Review and apply the plan path shown in the browser with: bsig apply <plan-path>\n'
       exit 0
     fi

--- a/install/engine_bridge.py
+++ b/install/engine_bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from typing import Any
@@ -15,7 +16,7 @@ class EngineUnavailable(RuntimeError):
 class EngineBridge:
     def __init__(self, product: str):
         self.product = product
-        self.binary = shutil.which("bsig")
+        self.binary = os.environ.get("BSIG_BINARY") or shutil.which("bsig")
         if not self.binary:
             raise EngineUnavailable("bsig is not installed")
 
@@ -24,6 +25,8 @@ class EngineBridge:
             result = subprocess.run([self.binary, *args], input=stdin, capture_output=True, timeout=timeout, check=False)
         except subprocess.TimeoutExpired as error:
             raise EngineUnavailable("Engine did not resolve its signed catalog in time") from error
+        except OSError as error:
+            raise EngineUnavailable("Engine could not be started") from error
         events = []
         for line in result.stdout.decode("utf-8", "replace").splitlines():
             try:

--- a/install/setup_server.py
+++ b/install/setup_server.py
@@ -601,9 +601,9 @@ def main():
     try:
         engine_bridge = EngineBridge("spotlight")
         engine_descriptor = engine_bridge.descriptor()
-    except (EngineUnavailable, RuntimeError, KeyError):
-        engine_bridge = None
-        engine_descriptor = None
+    except (EngineUnavailable, RuntimeError, KeyError) as error:
+        print(f"A compatible Buried Signals Engine is required: {error}", file=sys.stderr)
+        return 1
 
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, *_):
@@ -635,7 +635,10 @@ def main():
                 self._send(404, "not found", "text/plain")
 
         def do_POST(self):
-            if self.path not in ("/submit", "/pick-folder", "/engine-submit"):
+            if self.path == "/submit":
+                self._send(410, json.dumps({"errors":[{"field":"","message":"The legacy writer is retired; submit through Engine."}]}))
+                return
+            if self.path not in ("/pick-folder", "/engine-submit"):
                 self._send(404, "not found", "text/plain")
                 return
             try:
@@ -655,8 +658,6 @@ def main():
                 self._send(200, json.dumps({"path": path, "error": error}))
                 return
             if self.path == "/engine-submit":
-                if engine_bridge is None:
-                    self._send(409, json.dumps({"errors":[{"field":"","message":"A compatible Engine descriptor is unavailable; reload to use the legacy installer."}]})); return
                 try:
                     response = engine_bridge.submit(payload.get("request") or {}, payload.get("secrets") or {})
                     marker = os.path.join(args.profile_dir, "engine-plan.ready")

--- a/tests/configurator-server-check.py
+++ b/tests/configurator-server-check.py
@@ -344,11 +344,30 @@ class ServerChecks(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tmp = tempfile.mkdtemp()
+        cls.fake_bsig = os.path.join(cls.tmp, "bsig")
+        with open(cls.fake_bsig, "w", encoding="utf-8") as handle:
+            handle.write("""#!/usr/bin/env python3
+import json, sys
+args = sys.argv[1:]
+if args[:2] == ["configure", "describe"]:
+    data = {"descriptor": {"schema_version": "bsig-configure-descriptor/v1", "product": "spotlight", "fields": []}}
+elif args[:2] == ["configure", "validate"]:
+    json.load(sys.stdin); data = {"normalized": {"required_secret_ids": []}}
+elif args[:2] == ["keys", "list"]:
+    data = {"keys": []}
+elif args[:2] == ["configure", "plan"]:
+    json.load(sys.stdin); data = {"plan_path": "/tmp/spotlight-install.json"}
+else:
+    sys.exit(4)
+print(json.dumps({"event": "result", "data": data}))
+""")
+        os.chmod(cls.fake_bsig, 0o755)
+        env = {**os.environ, "BSIG_BINARY": cls.fake_bsig}
         cls.proc = subprocess.Popen(
             [sys.executable, os.path.join(ROOT, "install", "setup_server.py"),
              "--profile-dir", cls.tmp, "--repo-dir", ROOT,
              "--port", "0", "--no-browser", "--skip-key-validation"],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
         # GET is token-gated, so the token comes from the printed URL.
         cls.token = None
         deadline = time.time() + 10
@@ -407,36 +426,31 @@ class ServerChecks(unittest.TestCase):
                 urllib.request.urlopen(url, timeout=5)
             self.assertEqual(ctx.exception.code, 403, url)
 
-        # 3. bad token is rejected on both POST endpoints
-        for path in ("/submit", "/pick-folder"):
+        # 3. bad token is rejected on both active POST endpoints
+        for path in ("/engine-submit", "/pick-folder"):
             with self.assertRaises(urllib.error.HTTPError) as ctx:
                 self.post(path, {**BASE, "token": "wrong", "field": "vault_path"})
             self.assertEqual(ctx.exception.code, 403, path)
 
-        # 4. structural validation blocks with field errors
+        # 4. the legacy writer endpoint is retired
         with self.assertRaises(urllib.error.HTTPError) as ctx:
             self.post("/submit", {**BASE, "token": self.token, "navKey": ""})
-        self.assertEqual(ctx.exception.code, 400)
-        body = json.loads(ctx.exception.read())
-        self.assertTrue(any(e["field"] == "nav_key" for e in body["errors"]))
+        self.assertEqual(ctx.exception.code, 410)
 
-        # 5. good submit writes the three artifacts and exits 0
-        resp = self.post("/submit", {**BASE, "token": self.token})
+        # 5. Engine submit writes only the sealed-plan marker and exits 0
+        resp = self.post("/engine-submit", {
+            "token": self.token,
+            "request": {"schema_version": "bsig-configure/v1"},
+            "secrets": {},
+        })
         self.assertTrue(resp["ok"])
         self.assertEqual(self.proc.wait(timeout=10), 0)
         self.assertEqual(stat.S_IMODE(os.stat(self.tmp).st_mode), 0o700)
-        expected = {".env": 0o600, "setup-config.env": 0o600, "getting-started.html": 0o644}
-        self.assertEqual(set(os.listdir(self.tmp)), set(expected))
-        for name, mode in expected.items():
-            path = os.path.join(self.tmp, name)
-            self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), mode, name)
-        guide = read(os.path.join(self.tmp, "getting-started.html"))
-        cfg = read(os.path.join(self.tmp, "setup-config.env"))
-        for secret in SECRETS:
-            self.assertNotIn(secret, guide)
-            self.assertNotIn(secret, cfg)
-        self.assertIn("SPOTLIGHT_DIR_INPUT='~/Documents/Spotlight'", cfg)
-        self.assertIn("SPOTLIGHT_VAULT_INPUT='~/Intelligence'", cfg)
+        marker = os.path.join(self.tmp, "engine-plan.ready")
+        self.assertEqual(stat.S_IMODE(os.stat(marker).st_mode), 0o600)
+        with open(marker, encoding="utf-8") as handle:
+            self.assertEqual(json.load(handle)["plan_path"], "/tmp/spotlight-install.json")
+        self.assertEqual(set(os.listdir(self.tmp)), {"bsig", "engine-plan.ready"})
 
 
 if __name__ == "__main__":

--- a/tests/install-spotlight-check.sh
+++ b/tests/install-spotlight-check.sh
@@ -22,9 +22,11 @@ excludes() {
 # ── install-spotlight.sh: configurator head contract ──
 # Configurator phase: local server collects config, installer sources artifacts
 includes install-spotlight.sh 'python3 "$CONFIGURATOR_DIR/install/setup_server.py" --profile-dir "$SPOTLIGHT_PROFILE_DIR" --repo-dir "$CONFIGURATOR_DIR"'
+includes install-spotlight.sh 'rm -f "$ENGINE_PLAN_MARKER"'
+includes install-spotlight.sh 'if [ -f "$ENGINE_PLAN_MARKER" ]; then'
+excludes install/setup_server.py 'reload to use the legacy installer'
 # Engine marker gate: server exit code alone is not trusted and the legacy
 # Obsidian/QMD installer is never used as a silent fallback.
-includes install-spotlight.sh 'if [ -f "$SPOTLIGHT_PROFILE_DIR/engine-plan.ready" ]; then'
 includes install-spotlight.sh 'no legacy Obsidian/QMD fallback was applied'
 includes install-spotlight.sh 'if ! command -v bsig >/dev/null 2>&1; then'
 # Version handshake with install/setup_server.py + install/configure.html


### PR DESCRIPTION
## Summary
- require a valid Engine descriptor before serving configuration
- retire the legacy configurator submit endpoint
- clear stale sealed-plan markers before each run
- test the real Engine bridge boundary with a fake bsig process

## Verification
- all 64 Spotlight smoke checks pass