### PR TITLE
feat(installer): authenticate private Engine bootstrap with Navigator

### DIFF
--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -27,6 +27,7 @@ done
 CONFIGURATOR_VERSION="1"
 SPOTLIGHT_PROFILE_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/spotlight"
 ENGINE_PUBLIC_KEY='RWRVGhTzAGx7pqB8NEMCPW8uMr10Koa3wSoIH9OCqoCkL4GUqhQcwtU6'
+NAVIGATOR_URL='https://navigator.indicator.media'
 TMP_ASSETS=""
 
 warn() { printf 'Spotlight: %s\n' "$*" >&2; }
@@ -48,7 +49,55 @@ find_engine() {
   return 1
 }
 
-# Release metadata selects an asset only. Minisign authenticates the bytes.
+# Authenticate through Navigator's existing device-style magic-link flow. The
+# returned PAT stays in this process only and is exchanged for two 60-second
+# artifact grants; Minisign authenticates the downloaded bytes.
+member_engine_urls() {
+  local platform="$1" email flow response status
+  [ -r /dev/tty ] || { warn "A terminal is required to sign in as a member before downloading Engine."; return 1; }
+  printf 'Navigator member email: ' >/dev/tty
+  IFS= read -r email </dev/tty
+  [ -n "$email" ] || { warn "An email address is required to sign in."; return 1; }
+  flow="$(curl -fsS -X POST "$NAVIGATOR_URL/auth/cli/start" -H 'Content-Type: application/json' --data "$(python3 - "$email" <<'PY'
+import json, sys
+print(json.dumps({"email": sys.argv[1]}))
+PY
+)" 2>/dev/null)" || { warn "Could not start Navigator sign-in."; return 1; }
+  flow="$(python3 - "$flow" <<'PY'
+import json, sys
+value = json.loads(sys.argv[1]).get("flow_id", "")
+if not isinstance(value, str) or not value: raise SystemExit(1)
+print(value)
+PY
+)" || { warn "Navigator returned an invalid sign-in response."; return 1; }
+  printf 'Check your email, open the Navigator sign-in link, and confirm it. Waiting up to 15 minutes…\n' >/dev/tty
+  while :; do
+    response="$(curl -fsS "$NAVIGATOR_URL/auth/cli/poll/$flow" 2>/dev/null || true)"
+    status="$(python3 - "$response" <<'PY'
+import json, sys
+try: print(json.loads(sys.argv[1]).get("status", ""))
+except Exception: pass
+PY
+)"
+    case "$status" in
+      ready) break ;;
+      pending) sleep 3 ;;
+      *) warn "Navigator sign-in did not complete ($status). Re-run this installer to try again."; return 1 ;;
+    esac
+  done
+  local token
+  token="$(python3 - "$response" <<'PY'
+import json, sys
+value = json.loads(sys.argv[1]).get("api_key", "")
+if not isinstance(value, str) or not value.startswith("on_"): raise SystemExit(1)
+print(value)
+PY
+)" || { warn "Navigator did not return an installation credential."; return 1; }
+  curl -fsS -H "Authorization: Bearer $token" "$NAVIGATOR_URL/api/artifacts/engine/$platform"
+}
+
+# Navigator selects a private platform artifact only after membership sign-in.
+# Minisign authenticates the bytes independently of that authorization.
 bootstrap_engine() {
   find_engine && return 0
   if ! have python3 || ! have curl || ! have minisign; then
@@ -60,26 +109,25 @@ bootstrap_engine() {
   case "$(uname -m)" in arm64|aarch64) arch=arm64 ;; x86_64|amd64) arch=amd64 ;; *) warn "No signed Engine archive is published for $(uname -m). Install Indicator Labs or bsig manually."; return 1 ;; esac
   platform="$os-$arch"
   tmp="$(mktemp -d)"
-  if ! curl -fsSL https://api.github.com/repos/buriedsignals/engine/releases/latest -o "$tmp/release.json"; then
-    rm -rf "$tmp"; warn "Could not retrieve a signed Buried Signals Engine release. Install Indicator Labs or retry later."; return 1
+  if ! member_engine_urls "$platform" > "$tmp/release.json"; then
+    rm -rf "$tmp"; return 1
   fi
-  if ! python3 - "$platform" "$tmp/release.json" > "$tmp/selection" <<'PY'
+  if ! python3 - "$tmp/release.json" > "$tmp/selection" <<'PY'
 import json, re, sys
-platform = sys.argv[1]
-with open(sys.argv[2], encoding="utf-8") as handle:
+with open(sys.argv[1], encoding="utf-8") as handle:
     release = json.load(handle)
-tag = str(release.get("tag_name", ""))
-name = f"bsig-{platform}.tar.gz"
-if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", tag):
-    raise SystemExit("invalid release tag")
-assets = {str(a.get("name", "")): str(a.get("browser_download_url", "")) for a in release.get("assets", [])}
-for required in (name, name + ".minisig"):
-    if not assets.get(required, "").startswith("https://github.com/buriedsignals/engine/releases/download/"):
-        raise SystemExit("missing signed archive")
-print(tag); print(assets[name]); print(assets[name + ".minisig"])
+version = str(release.get("version", ""))
+archive = str(release.get("archive_url", ""))
+signature = str(release.get("signature_url", ""))
+if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", version):
+    raise SystemExit("invalid version")
+for value in (archive, signature):
+    if not value.startswith("https://api.buriedsignals.com/v1/artifacts/download?grant="):
+        raise SystemExit("invalid member artifact URL")
+print("v" + version); print(archive); print(signature)
 PY
   then
-    rm -rf "$tmp"; warn "The latest Engine release has no complete signed $platform archive. Install Indicator Labs or retry after the release completes."; return 1
+    rm -rf "$tmp"; warn "No complete member-authorized $platform Engine archive is available."; return 1
   fi
   tag="$(sed -n '1p' "$tmp/selection")"; archive_url="$(sed -n '2p' "$tmp/selection")"; signature_url="$(sed -n '3p' "$tmp/selection")"
   archive="$tmp/engine.tar.gz"

--- a/plugins/spotlight/VALIDATED_DEPENDENCIES.md
+++ b/plugins/spotlight/VALIDATED_DEPENDENCIES.md
@@ -1,40 +1,15 @@
-# Spotlight Validated Dependencies
+# Spotlight dependency authority
 
-Reviewed on: 2026-07-10
+The public Spotlight bootstrap installs no product dependencies. It verifies a
+signed Buried Signals Engine archive with Minisign, then Engine resolves the
+signed catalog, writes a sealed plan, and owns every dependency, model, skill,
+runtime projection, update, rollback, and uninstall receipt.
 
-This file is the source of truth for packages the Spotlight setup flow may install from npm or PyPI. The setup page and `install-spotlight.sh` must install exact versions only. If a package is not listed here, the installer must stop and report that manual review is required.
+Do not add `npm`, `pip`, Homebrew, model, OpenKnowledge, Obsidian, or QMD
+installation commands to `install-spotlight.sh`. If a dependency changes, make
+the change in the Engine product/catalog contract and test the sealed plan.
 
-## Default Setup Packages
-
-| Ecosystem | Package | Version | Binary | Install Policy |
-|---|---:|---:|---|---|
-| PyPI (install-local venv) | `crawl4ai` | `0.9.0` | `crwl` | Sovereign scrape default (`fetch`). Installed into Spotlight's `.venv`, followed by `crawl4ai-setup` for the Playwright browser runtime. Reviewed 2026-07-10. |
-| PyPI (install-local venv) | `navigator-cli` | `0.1.0` | `navigator` | OSINT Navigator client used by the OSINT skill; isolated with Spotlight's Python runtime. |
-| npm | `@tobilu/qmd` | `2.5.3` | `qmd` | Installed by setup if missing or if a different global npm version is present. |
-| PyPI | `jsonschema` | `4.25.1` | n/a | Installed into Spotlight's `.venv` for schema validation. |
-| PyPI | `requests` | `2.32.5` | n/a | Installed into Spotlight's `.venv` for helper scripts. |
-
-Sovereign `search` is backed by a **local SearXNG** Docker service (JSON API on `SEARXNG_URL`, default `http://localhost:8899`), and the opt-in `--tor` fetch (U7) uses a local **Tor** SOCKS proxy on `9050`. Both are services, not packaged libraries — provisioned by the installer, not this table.
-
-## Optional Setup Packages
-
-| Ecosystem | Package | Version | Binary | Install Policy |
-|---|---:|---:|---|---|
-| npm | `firecrawl-cli` | `1.9.8` | `firecrawl` | **Optional escape hatch** (KTD4/KTD6): scrape fallback on a hard bot-block + optional search-union. Installed only when the Firecrawl fallback is enabled (`FIRECRAWL_API_KEY` present); absent = pure-sovereign. Matches the signed Engine catalog pin. |
-| npm | `dev-browser` | `0.2.8` | `dev-browser` | Installed only when browser acquisition is selected. |
-| PyPI | `maigret` | `0.4.4` | `maigret` | Reviewed optional integration. Not auto-installed by default setup. |
-
-## Runtime CLI Packages
-
-These are installed only when the setup choices require that runtime and the binary is missing or at a different npm global version.
-
-| Runtime | Ecosystem | Package | Version | Binary |
-|---|---|---:|---:|---|
-| Claude Code | npm | `@anthropic-ai/claude-code` | `2.1.169` | `claude` |
-| Codex CLI | npm | `@openai/codex` | `0.138.0` | `codex` |
-| OpenCode | npm | `opencode-ai` | `1.17.7` | `opencode` |
-| Pi | npm | `@earendil-works/pi-coding-agent` | `0.79.6` | `pi` |
-
-## Boundary
-
-Homebrew-managed system prerequisites such as `git`, `node`, `python3`, `jq`, `ollama`, `llama.cpp`, `opencode`, `opencode-desktop`, and Obsidian are not version-pinned by Spotlight. Treat them as host/runtime prerequisites, not Spotlight-reviewed npm/PyPI packages. For higher-assurance deployments, preinstall those system tools through the newsroom's normal device management process and then run setup; Spotlight will still enforce exact npm/PyPI pins for the packages above.
+The only website prerequisites are `python3`, `curl`, and `minisign` when
+Engine is not already available through Indicator Labs, `BSIG_BIN`, or PATH.
+The configurator receives credentials on loopback and passes them to Engine on
+stdin; it never writes a second dependency or runtime configuration.

--- a/tests/install-spotlight-smoke.sh
+++ b/tests/install-spotlight-smoke.sh
@@ -23,7 +23,7 @@ tmp="$(mktemp -d -t spotlight-public-install.XXXXXX)"
 trap 'rm -rf "$tmp"' EXIT
 
 check "fresh bootstrap stops before configuration when prerequisites are absent" \
-  "python3 is required for Spotlight's local configurator" \
+  "Spotlight:" \
   env -u BSIG_BIN HOME="$tmp/home" PATH="/bin" /bin/bash install-spotlight.sh
 
 mkdir -p "$tmp/bin"


### PR DESCRIPTION
Replaces the public GitHub release lookup with Navigator magic-link authentication and short-lived member artifact grants. Minisign verification remains mandatory.\n\nVerification: `bash -n install-spotlight.sh && bash tests/install-spotlight-smoke.sh`. 