### PR TITLE
docs(landing): align runtime copy and deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,22 @@ sensitive: false
 
 # Spotlight — Runtime Contract
 
+## Landing Site Deployment
+
+The production landing site is GitHub Pages at
+`https://spotlight.buriedsignals.com/`. GitHub Pages is configured in legacy
+branch mode with `main` and the repository root (`/`) as its source. There is
+no Render service and no in-repository deployment workflow for the landing
+site: merging or pushing the intended site changes to `main` triggers the
+Pages build.
+
+Before merging, validate the affected static HTML and the repository checks
+appropriate to the change. After merging, confirm the Pages source and status
+with `gh api repos/buriedsignals/spotlight/pages`, inspect the newest
+`github-pages` deployment for the merged SHA, and verify the changed copy at
+the production URL. GitHub Pages may serve cached content for up to ten
+minutes, so do not treat an immediately stale response as a failed deploy.
+
 ## Session Preflight
 
 Before coding in this project on a Buried Signals dev machine, read the shared `coding-rules` skill (`kit/coding-rules/SKILL.md` in the sibling shared-skills repo, if present). It is the canonical source for workflow routing, coding standards, Jujutsu/version-control rules, GitHub operations, and parallel-agent isolation. Local instructions below add project-specific constraints.

--- a/index.html
+++ b/index.html
@@ -1802,7 +1802,7 @@
     <div class="int-card" data-reveal="card" data-stagger-idx="0">
       <div class="idx">01 / 06</div>
       <div class="name">Agent runtimes</div>
-      <div class="desc">Claude Code, Codex, Gemini, OpenCode, Goose, Hermes, or local models. Use the runtime that fits the investigation.</div>
+      <div class="desc">Claude Code, Codex, Pi, OpenCode, or the local Flue-on-Pi harness. Use the configured runtime that fits the investigation.</div>
     </div>
     <div class="int-card" data-reveal="card" data-stagger-idx="1">
       <div class="idx">02 / 06</div>
@@ -1837,17 +1837,14 @@
 <section id="works-with" data-screen-label="05 Works with" data-nav-theme="dark" data-scene-mood="sparse">
   <div class="header">
     <span class="chap" data-reveal="meta">Ch. 03 — Works with</span>
-    <h2 class="title" data-reveal="title" style="--rd: 120ms">Runs with your preferred agent.</h2>
+    <h2 class="title" data-reveal="title" style="--rd: 120ms">Choose your agent runtime.</h2>
   </div>
   <div class="works-chips" data-reveal="body" style="--rd: 200ms">
     <a class="works-chip" href="https://claude.com/claude-code" target="_blank" rel="noopener">Claude Code</a>
-    <a class="works-chip" href="https://claude.ai" target="_blank" rel="noopener">Claude</a>
     <a class="works-chip" href="https://openai.com/codex" target="_blank" rel="noopener">Codex</a>
-    <a class="works-chip" href="https://chatgpt.com" target="_blank" rel="noopener">ChatGPT</a>
-    <a class="works-chip" href="https://gemini.google.com" target="_blank" rel="noopener">Gemini</a>
-    <a class="works-chip" href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a>
+    <a class="works-chip" href="https://pi.dev/" target="_blank" rel="noopener">Pi</a>
     <a class="works-chip" href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a>
-    <span class="works-chip works-chip-static">Hermes</span>
+    <span class="works-chip works-chip-static">Local · Flue on Pi</span>
   </div>
   <div class="install-reminder" data-reveal="body" style="--rd: 260ms">
     <a href="setup.html" class="cta">Install Spotlight <span aria-hidden="true">→</span></a>
@@ -1941,7 +1938,7 @@
 <section id="acknowledgements" data-screen-label="07.5 Acknowledgements" data-nav-theme="dark" data-scene-mood="calm">
   <span class="ack__tag" data-reveal="meta">Standing on open work</span>
   <ul class="ack__list" role="list" data-reveal="body" data-stagger-idx="0">
-    <li><a href="https://github.com/7onez/cti-expert" target="_blank" rel="noopener">CTI Expert · Hieu Ngo / chongluadao.vn · GitHub: 7onez</a> — source for selected passive technical-investigation, coverage, contradiction, and public-ledger methods; substantially adapted at <code>f9ecc9b</code> · MIT + upstream Ethical Use Addendum</li>
+    <li><a href="https://github.com/7onez/cti-expert" target="_blank" rel="noopener">CTI Expert</a> — Hieu Ngo / chongluadao.vn (7onez) · selected investigation methods · MIT + Ethical Use Addendum</li>
     <li><a href="https://github.com/jamditis/claude-skills-journalism" target="_blank" rel="noopener">Joe Amditis</a> — content-access + social-media-intelligence, adapted · MIT</li>
     <li><a href="https://hapgood.us/2019/06/19/sift-the-four-moves/" target="_blank" rel="noopener">Mike Caulfield</a> — the SIFT verification method</li>
     <li><a href="https://www.bellingcat.com/" target="_blank" rel="noopener">Bellingcat</a> — investigation techniques</li>


### PR DESCRIPTION
## What changed

- Shorten the CTI Expert acknowledgement and remove the reviewed-revision wording.
- Advertise only the agent runtimes exposed by the Spotlight configurator.
- Document the GitHub Pages main-root production deployment path in AGENTS.md.

## Why

The public landing copy had drifted from the supported runtime configuration and carried stale attribution wording. Deployment ownership was also undocumented locally.

## Validation

- Spotlight eval: 46/46 checks passed.
- Installer and landing-page fragment checks passed.
- index.html, setup.html, and install/configure.html parse with balanced tags.
- Local smoke retains pre-existing plugin-distribution/configurator startup failures unrelated to this diff.