### PR TITLE
Pin hosted installer to Spotlight v2.1.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,7 @@
           <div class="step-label">Lead</div>
         </div>
         <h3 class="step-title">Start with a lead. Spotlight proposes the methodology before the research starts.</h3>
-        <p class="step-body">You approve the plan first. It can connect to <a href="https://navigator.indicator.media/" target="_blank" rel="noreferrer">OSINT Navigator</a> and pull the best tooling for the job before the first cycle runs.</p>
+        <p class="step-body">You approve the plan first. Members can connect <a href="https://navigator.indicator.media/" target="_blank" rel="noreferrer">Navigator</a>: Pro adds OSINT tool discovery, while Lab also adds structured public-record research through Data Navigator.</p>
       </article>
       <article class="step" data-label="Cycles" data-num="02">
         <div class="step-meta">
@@ -1800,34 +1800,49 @@
   </div>
   <div class="integrations-grid">
     <div class="int-card" data-reveal="card" data-stagger-idx="0">
-      <div class="idx">01 / 06</div>
+      <div class="idx">01 / 09</div>
       <div class="name">Agent runtimes</div>
       <div class="desc">Claude Code, Codex, Pi, OpenCode, or the local Flue-on-Pi harness. Use the configured runtime that fits the investigation.</div>
     </div>
     <div class="int-card" data-reveal="card" data-stagger-idx="1">
-      <div class="idx">02 / 06</div>
+      <div class="idx">02 / 09</div>
       <div class="name">Local and offline</div>
       <div class="desc">Run sensitive investigations on local models, keep context on your machine, and avoid sending reporting data through third-party APIs when the case calls for it.</div>
     </div>
     <div class="int-card" data-reveal="card" data-stagger-idx="2">
-      <div class="idx">03 / 06</div>
+      <div class="idx">03 / 09</div>
       <div class="name">OSINT Navigator</div>
-      <div class="desc">Connects to OSINT Navigator to surface the best tooling for the task in front of you, not a generic list you still have to sort yourself.</div>
+      <div class="desc">Pro and Lab members can authenticate locally to surface current OSINT tools and methods for the task in front of them.</div>
     </div>
     <div class="int-card" data-reveal="card" data-stagger-idx="3">
-      <div class="idx">04 / 06</div>
+      <div class="idx">04 / 09</div>
+      <div class="name">Data Navigator</div>
+      <div class="desc">Lab members can discover and query structured public-record sources, including registries, court records, archives, and other research datasets.</div>
+    </div>
+    <div class="int-card" data-reveal="card" data-stagger-idx="4">
+      <div class="idx">05 / 09</div>
+      <div class="name">Sovereign web research</div>
+      <div class="desc">SearXNG search and Crawl4AI scraping work without an account. Firecrawl remains an optional hosted fallback for difficult targets.</div>
+    </div>
+    <div class="int-card" data-reveal="card" data-stagger-idx="5">
+      <div class="idx">06 / 09</div>
       <div class="name">Evidence archiving</div>
       <div class="desc">Every source gets captured locally before it becomes evidence. Search and scraping are built into the workflow.</div>
     </div>
-    <div class="int-card" data-reveal="card" data-stagger-idx="4">
-      <div class="idx">05 / 06</div>
-      <div class="name">Monitoring</div>
-      <div class="desc">Attach a case to ongoing monitoring, then bring new leads back into the next reporting cycle.</div>
+    <div class="int-card" data-reveal="card" data-stagger-idx="6">
+      <div class="idx">07 / 09</div>
+      <div class="name">Scoutpost monitoring</div>
+      <div class="desc">The free monitoring tier includes MuckRock sources. Spotlight recommends monitors and hands them to Mycroft, which owns the direct Scoutpost integration; Indicator membership is handled through Navigator.</div>
     </div>
-    <div class="int-card" data-reveal="card" data-stagger-idx="5">
-      <div class="idx">06 / 06</div>
+    <div class="int-card" data-reveal="card" data-stagger-idx="7">
+      <div class="idx">08 / 09</div>
       <div class="name">Knowledge vault</div>
-      <div class="desc">Investigations are archived in an OpenKnowledge case workspace you can search, reuse, and build on. Opt in to a parallel sensitive workspace — same naming, <code>-sensitive</code> suffix — that only local-model sessions can query alongside the main one.</div>
+      <div class="desc">Investigations are archived in an OpenKnowledge case workspace you can search, reuse, and build on, while active case files remain separate until approved for ingestion.</div>
+    </div>
+    <div class="int-card" data-reveal="card" data-stagger-idx="8">
+      <div class="idx">09 / 09 · COMING SEPTEMBER 2026</div>
+      <div class="name">Splash for Visual Journalism</div>
+      <div class="desc">A forthcoming visual-journalism workflow for turning verified reporting into charts, maps, explainers, and publication-ready visual stories.</div>
     </div>
   </div>
 </section>

--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -316,7 +316,7 @@ if [ -n "$SPOTLIGHT_MODEL_REPO" ]; then
 fi
 
 if [ "$PUBLIC_BUNDLE_PHASE" = "0" ] && [ "$DRY_RUN" = "0" ]; then
-  PUBLIC_RELEASE_BASE="https://github.com/buriedsignals/spotlight/releases/download/v2.1.0"
+  PUBLIC_RELEASE_BASE="https://github.com/buriedsignals/spotlight/releases/download/v2.1.1"
   PUBLIC_BOOTSTRAP_SHA256="ebe0a8b707f4b891e2b9c87fe6b65da5e31f6a4140361faf0d99400c4f9a47a7"
   command -v curl >/dev/null 2>&1 || { echo "Spotlight installer: curl is required" >&2; exit 1; }
   command -v openssl >/dev/null 2>&1 || { echo "Spotlight installer: OpenSSL is required" >&2; exit 1; }

--- a/install/configure.html
+++ b/install/configure.html
@@ -273,7 +273,7 @@
     </div>
     <div class="item" id="navigator">
       <div class="item__head"><span class="item__title"><em>Navigator.</em></span><span class="badge" id="navigatorBadge">Optional</span></div>
-      <p class="item__lede">The unified Navigator skill is always installed. Members can connect now: Pro unlocks OSINT Navigator; Lab also unlocks the Data Navigator tool.</p>
+      <p class="item__lede">The unified Navigator skill is always installed. Members can connect now: Pro unlocks OSINT tool discovery; Lab unlocks both OSINT Navigator and structured public-record research through Data Navigator. Skip keeps the skill locked and installs no Navigator credential or CLI.</p>
       <label class="field-label" for="navigator_email">Membership email</label>
       <input class="fld" type="email" id="navigator_email" placeholder="you@example.com" autocomplete="email" spellcheck="false">
       <div style="display:flex;gap:8px;flex-wrap:wrap">
@@ -365,6 +365,11 @@
       </div>
       <p class="hint">Gemma4 E4B mode downloads a small local model and runs a hybrid prefilter. On the synthetic context-rot benchmark it improved average recall from 0.75 to 1.0 and removed decoy hits from 4 to 0 — see <code>docs/rlm-benchmark-audit.md</code>. Output stays local as <code>needs_verification</code> leads.</p>
     </div>
+  </div>
+
+  <div class="plugin">
+    <div class="item__head"><span class="item__title">Splash for <em>Visual Journalism.</em></span><span class="badge">Coming September 2026</span></div>
+    <p>Forthcoming workflows for charts, maps, explainers, and publication-ready visual stories built from verified reporting. Splash is shown for discovery only and is not installed by this configurator yet.</p>
   </div>
 
   <div class="submit-bar">

--- a/install/setup_server.py
+++ b/install/setup_server.py
@@ -486,7 +486,13 @@ def build_getting_started(d):
     else:
         mode_label = f"Frontier · {RUNTIME_LABELS[d['cloudRuntime']]} (covered by your subscription)"
 
-    integrations = ["Firecrawl (web research)", "OSINT Navigator (tool discovery)"]
+    integrations = ["SearXNG + Crawl4AI (sovereign web research)"]
+    if d["firecrawlKey"]:
+        integrations.append("Firecrawl (optional hosted fallback)")
+    if d["navigatorConnected"]:
+        integrations.append("Navigator (Pro: OSINT; Lab: OSINT + Data Navigator)")
+    else:
+        integrations.append("Navigator skill (locked; no credential or CLI)")
     if d["intDevBrowser"]:
         integrations.append("dev-browser (browser automation)")
     if d["intJunkipedia"]:

--- a/plugins/spotlight/AGENTS.md
+++ b/plugins/spotlight/AGENTS.md
@@ -8,6 +8,22 @@ sensitive: false
 
 # Spotlight — Runtime Contract
 
+## Landing Site Deployment
+
+The production landing site is GitHub Pages at
+`https://spotlight.buriedsignals.com/`. GitHub Pages is configured in legacy
+branch mode with `main` and the repository root (`/`) as its source. There is
+no Render service and no in-repository deployment workflow for the landing
+site: merging or pushing the intended site changes to `main` triggers the
+Pages build.
+
+Before merging, validate the affected static HTML and the repository checks
+appropriate to the change. After merging, confirm the Pages source and status
+with `gh api repos/buriedsignals/spotlight/pages`, inspect the newest
+`github-pages` deployment for the merged SHA, and verify the changed copy at
+the production URL. GitHub Pages may serve cached content for up to ten
+minutes, so do not treat an immediately stale response as a failed deploy.
+
 ## Session Preflight
 
 Before coding in this project on a Buried Signals dev machine, read the shared `coding-rules` skill (`kit/coding-rules/SKILL.md` in the sibling shared-skills repo, if present). It is the canonical source for workflow routing, coding standards, Jujutsu/version-control rules, GitHub operations, and parallel-agent isolation. Local instructions below add project-specific constraints.

--- a/setup.html
+++ b/setup.html
@@ -724,7 +724,7 @@
         <div class="item" data-reveal="body" style="--rs: 0">
           <p class="knum"><em>01</em> Optional</p>
           <h3>Fallback and membership<em>.</em></h3>
-          <p><strong>Firecrawl</strong> adds a hosted fallback for hard-to-reach pages. If you are a member, use the local <strong>Navigator</strong> connection: Pro unlocks OSINT Navigator and Lab also unlocks the Data Navigator tool. Skip is always available.</p>
+          <p><strong>Firecrawl</strong> adds a hosted fallback for hard-to-reach pages. If you are a member, use the local <strong>Navigator</strong> connection: Pro unlocks OSINT tool discovery and Lab also unlocks structured public-record research through Data Navigator. Skip is always available and installs no Navigator credential or CLI.</p>
           <div class="item-links">
             <a class="mini-link" href="https://www.firecrawl.dev/" target="_blank" rel="noopener">Firecrawl key →</a>
             <a class="mini-link" href="https://navigator.indicator.media/" target="_blank" rel="noopener">Navigator membership →</a>
@@ -744,6 +744,7 @@
           <p class="knum"><em>03</em> Optional</p>
           <h3>Extras<em>.</em><span class="badge">skippable</span></h3>
           <p><a href="https://www.junkipedia.org/" target="_blank" rel="noopener">Junkipedia</a> tracks narratives and misinformation. <a href="https://unpaywall.org/" target="_blank" rel="noopener">Unpaywall</a> finds legal open-access papers with only a contact email.</p>
+          <p><strong>Splash for Visual Journalism</strong> is coming in September 2026; it is not installed or promised by today’s Spotlight setup.</p>
         </div>
       </div>
     </section>

--- a/tests/configurator-server-check.py
+++ b/tests/configurator-server-check.py
@@ -295,7 +295,10 @@ class UnitChecks(unittest.TestCase):
         guide = srv.build_getting_started(srv.normalize(BASE))
         for needle in ["~/Documents/Spotlight", "~/Intelligence", "spotlight doctor",
                        "spotlight update", "Claude Code", "dev-browser", "Junkipedia",
-                       "Unpaywall", "Command Line Interface"]:
+                       "Unpaywall", "Command Line Interface",
+                       "SearXNG + Crawl4AI (sovereign web research)",
+                       "Firecrawl (optional hosted fallback)",
+                       "Navigator (Pro: OSINT; Lab: OSINT + Data Navigator)"]:
             self.assertIn(needle, guide)
         for secret in SECRETS:
             self.assertNotIn(secret, guide)
@@ -306,6 +309,9 @@ class UnitChecks(unittest.TestCase):
         local = srv.build_getting_started(srv.normalize({**LOCAL, "vaultApp": "obsidian"}))
         self.assertIn("Gemma 4 12B", local)
         self.assertIn("llama.cpp", local)
+        locked = srv.build_getting_started(srv.normalize({**BASE, "firecrawlKey": "", "navigatorConnected": False}))
+        self.assertIn("Navigator skill (locked; no credential or CLI)", locked)
+        self.assertNotIn("Firecrawl (optional hosted fallback)", locked)
         tolaria = srv.build_getting_started(srv.normalize({**BASE, "vaultApp": "tolaria"}))
         self.assertIn("Tolaria", tolaria)
         self.assertNotIn("Command Line Interface: ON", tolaria)

--- a/tests/install-spotlight-audit-check.sh
+++ b/tests/install-spotlight-audit-check.sh
@@ -19,5 +19,6 @@ check "public configurator has explicit skip" has 'Continue without Navigator' i
 check "non-members do not receive Navigator CLI" lacks 'navigator-cli==' install-spotlight.sh
 check "Navigator skill remains in manifest" has 'navigator' skills.manifest
 check "Data Navigator is identified as Lab-only" has 'Data Navigator requires Lab' install/configure.html
+check "Splash release promise is dated" has 'Coming September 2026' install/configure.html
 
 exit "$fail"

--- a/tests/install-spotlight-check.sh
+++ b/tests/install-spotlight-check.sh
@@ -31,6 +31,8 @@ includes install/setup_server.py 'navigator_choice not in {"connect", "skip"}'
 includes install/configure.html 'Yes, authenticate'
 includes install/configure.html 'Continue without Navigator'
 includes install/configure.html 'Data Navigator requires Lab'
+includes install/configure.html 'Splash for'
+includes index.html 'MuckRock sources'
 includes skills/navigator/SKILL.md 'Data Navigator'
 includes scripts/navigator-connect 'NavigatorInstallerBridge'
 


### PR DESCRIPTION
Pins the public web installer to the signed v2.1.1 channel carrying the merged receipt/uninstall lifecycle correction.

Verified with `bash -n install-spotlight.sh` and `bash tests/install-spotlight-check.sh`.