### PR TITLE
fix(installer): ignore generated Spotlight environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__/
 patch-spotlight-low-ram.sh
 
 # Dependencies and build outputs
+.venv/
 node_modules/
 dist/
 coverage/

--- a/tests/install-spotlight-check.sh
+++ b/tests/install-spotlight-check.sh
@@ -10,6 +10,7 @@ excludes() { if grep -qF -- "$2" "$1"; then note "$1 stale fragment present: $2"
 
 bash -n install-spotlight.sh || { echo "install-spotlight.sh does not parse"; exit 1; }
 [ -x scripts/spotlight-uninstall ] || note "scripts/spotlight-uninstall must be executable so install does not dirty the checkout"
+includes .gitignore '.venv/'
 
 includes install-spotlight.sh '--legacy-only'
 includes install-spotlight.sh 'navigator_bridge.py'


### PR DESCRIPTION
## What changed

- declare `.venv/` as generated Spotlight state
- add a static installer contract assertion for the ignore rule

## Why

The standalone installer provisions `.venv/` inside the Spotlight checkout. Because it was not ignored, the signed updater treated its own generated environment as an untracked local edit and refused an otherwise idempotent update.

## Validation

- `bash tests/install-spotlight-check.sh`
- `bash tests/install-spotlight-smoke.sh`

