### PR TITLE
Fix Spotlight uninstall-owned wrapper cleanup

### DIFF
--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -991,6 +991,7 @@ if [ "$SPOTLIGHT_MODE" = "local" ]; then
   else
     cat > "$HOME/.local/bin/spotlight-local" <<LAUNCHER_EOF
 #!/usr/bin/env bash
+# Managed by the Spotlight public installer.
 # Spotlight local launcher — llama.cpp serving (orchestrator + RLM) + the Flue/Pi harness.
 # ONE harness: this runs the same \`flue run spotlight\` app the evals exercise
 # (harness/flue in the Spotlight checkout) — local test == user experience.
@@ -1468,6 +1469,7 @@ if [ "$DRY_RUN" = "1" ]; then
 else
   cat > "$HOME/.local/bin/spotlight-doctor" <<DOCTOR_EOF
 #!/usr/bin/env bash
+# Managed by the Spotlight public installer.
 set -euo pipefail
 export PATH="\$HOME/.local/bin:\$HOME/.npm-global/bin:\$PATH"
 expand_path() {
@@ -1534,6 +1536,7 @@ DOCTOR_TAIL
 
   cat > "$HOME/.local/bin/spotlight-update" <<UPDATE_EOF
 #!/usr/bin/env bash
+# Managed by the Spotlight public installer.
 set -euo pipefail
 expand_path() {
   local input="\$1"

--- a/scripts/spotlight-uninstall
+++ b/scripts/spotlight-uninstall
@@ -23,10 +23,72 @@ if [ ! -f "$bootstrap" ]; then
   exit 1
 fi
 args=(--product spotlight --runtime "$runtime" --product-root "$product_root" --action uninstall)
+dry_run=0
 for arg in "$@"; do
   case "$arg" in
-    --remove-data|--force|--dry-run) args+=("$arg") ;;
+    --dry-run) dry_run=1; args+=("$arg") ;;
+    --remove-data|--force) args+=("$arg") ;;
     *) echo "usage: spotlight-uninstall [--remove-data] [--force] [--dry-run]" >&2; exit 2 ;;
   esac
 done
 bash "$bootstrap" "${args[@]}"
+
+remove_owned_link() {
+  local path="$1" expected_target="$2"
+  [ -L "$path" ] || return 0
+  if [ "$(readlink "$path")" != "$expected_target" ]; then
+    printf 'Preserving non-Spotlight symlink: %s\n' "$path" >&2
+    return 0
+  fi
+  if [ "$dry_run" = "1" ]; then
+    printf 'DRY-RUN: remove Spotlight symlink %s\n' "$path"
+  else
+    rm -f "$path"
+  fi
+}
+
+remove_owned_file() {
+  local path="$1" anchor_one="$2" anchor_two="$3"
+  [ -f "$path" ] && [ ! -L "$path" ] || return 0
+  if ! grep -qF -- "$anchor_one" "$path" || ! grep -qF -- "$anchor_two" "$path"; then
+    printf 'Preserving file without Spotlight ownership markers: %s\n' "$path" >&2
+    return 0
+  fi
+  if [ "$dry_run" = "1" ]; then
+    printf 'DRY-RUN: remove Spotlight wrapper %s\n' "$path"
+  else
+    rm -f "$path"
+  fi
+}
+
+remove_shell_block() {
+  local rc="$1" tmp_rc
+  [ -f "$rc" ] || return 0
+  grep -q '^# SPOTLIGHT-BEGIN' "$rc" || return 0
+  if ! grep -q '^# SPOTLIGHT-END' "$rc"; then
+    printf 'Preserving shell file with incomplete Spotlight markers: %s\n' "$rc" >&2
+    return 0
+  fi
+  if [ "$dry_run" = "1" ]; then
+    printf 'DRY-RUN: remove Spotlight shell block from %s\n' "$rc"
+    return 0
+  fi
+  tmp_rc="$(mktemp)"
+  awk '
+    /^# SPOTLIGHT-BEGIN/ { skip=1; next }
+    /^# SPOTLIGHT-END/ { skip=0; next }
+    !skip { print }
+  ' "$rc" > "$tmp_rc"
+  cat "$tmp_rc" > "$rc"
+  rm -f "$tmp_rc"
+}
+
+bin="$HOME/.local/bin"
+remove_owned_link "$bin/spotlight-navigator" "$product_root/scripts/navigator-connect"
+remove_owned_link "$bin/spotlight-uninstall" "$product_root/scripts/spotlight-uninstall"
+remove_owned_file "$bin/spotlight-doctor" 'SPOTLIGHT_DIR_DEFAULT_INPUT=' 'Spotlight doctor:'
+remove_owned_file "$bin/spotlight-update" 'SPOTLIGHT_DIR_DEFAULT_INPUT=' 'signed public update channel is missing'
+remove_owned_file "$bin/spotlight-local" 'Spotlight local launcher' 'SPOTLIGHT_DIR_DEFAULT_INPUT='
+remove_shell_block "$HOME/.zshrc"
+remove_shell_block "$HOME/.bashrc"
+remove_shell_block "$HOME/.profile"

--- a/tests/install-spotlight-check.sh
+++ b/tests/install-spotlight-check.sh
@@ -9,8 +9,13 @@ includes() { grep -qF -- "$2" "$1" || note "$1 missing fragment: $2"; }
 excludes() { if grep -qF -- "$2" "$1"; then note "$1 stale fragment present: $2"; fi; }
 
 bash -n install-spotlight.sh || { echo "install-spotlight.sh does not parse"; exit 1; }
+bash -n scripts/spotlight-uninstall || { echo "scripts/spotlight-uninstall does not parse"; exit 1; }
+bash tests/spotlight-uninstall-check.sh || { echo "Spotlight uninstall cleanup checks failed"; exit 1; }
 [ -x scripts/spotlight-uninstall ] || note "scripts/spotlight-uninstall must be executable so install does not dirty the checkout"
 includes .gitignore '.venv/'
+includes scripts/spotlight-uninstall 'remove_owned_link "$bin/spotlight-uninstall"'
+includes scripts/spotlight-uninstall 'remove_owned_file "$bin/spotlight-doctor"'
+includes scripts/spotlight-uninstall 'remove_shell_block "$HOME/.zshrc"'
 
 includes install-spotlight.sh '--legacy-only'
 includes install-spotlight.sh 'navigator_bridge.py'

--- a/tests/spotlight-uninstall-check.sh
+++ b/tests/spotlight-uninstall-check.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+export HOME="$fixture/home"
+export SHELL=/bin/zsh
+product_root="$HOME/spotlight"
+channel="$HOME/.local/share/buriedsignals/public-installer/spotlight"
+bin="$HOME/.local/bin"
+mkdir -p "$product_root/scripts" "$channel" "$bin" "$HOME/.config/spotlight"
+cp scripts/spotlight-uninstall "$product_root/scripts/spotlight-uninstall"
+cat > "$channel/bootstrap.sh" <<'BOOTSTRAP'
+#!/usr/bin/env bash
+set -euo pipefail
+case " $* " in
+  *' --dry-run '*) exit 0 ;;
+esac
+rm -rf "$HOME/spotlight"
+BOOTSTRAP
+chmod +x "$channel/bootstrap.sh"
+printf 'SPOTLIGHT_DIR_INPUT=%q\nSPOTLIGHT_RUNTIME=codex\n' "$product_root" > "$HOME/.config/spotlight/setup-config.env"
+ln -s "$product_root/scripts/navigator-connect" "$bin/spotlight-navigator"
+ln -s "$product_root/scripts/spotlight-uninstall" "$bin/spotlight-uninstall"
+printf '%s\n' '#!/usr/bin/env bash' 'SPOTLIGHT_DIR_DEFAULT_INPUT=x' 'echo "Spotlight doctor: OK"' > "$bin/spotlight-doctor"
+printf '%s\n' '#!/usr/bin/env bash' 'SPOTLIGHT_DIR_DEFAULT_INPUT=x' 'echo "signed public update channel is missing"' > "$bin/spotlight-update"
+printf '%s\n' '#!/usr/bin/env bash' '# user-owned file' > "$bin/spotlight-local"
+printf '%s\n' '# user setting' '# SPOTLIGHT-BEGIN — added by install-spotlight.sh' 'spotlight() { :; }' '# SPOTLIGHT-END' '# trailing setting' > "$HOME/.zshrc"
+
+bash "$product_root/scripts/spotlight-uninstall" --dry-run >/dev/null
+[ -L "$bin/spotlight-uninstall" ]
+grep -q '^# SPOTLIGHT-BEGIN' "$HOME/.zshrc"
+
+bash "$product_root/scripts/spotlight-uninstall"
+[ ! -e "$bin/spotlight-navigator" ]
+[ ! -e "$bin/spotlight-uninstall" ]
+[ ! -e "$bin/spotlight-doctor" ]
+[ ! -e "$bin/spotlight-update" ]
+[ -f "$bin/spotlight-local" ]
+grep -q '^# user setting$' "$HOME/.zshrc"
+grep -q '^# trailing setting$' "$HOME/.zshrc"
+! grep -q '^# SPOTLIGHT-' "$HOME/.zshrc"
+printf 'spotlight uninstall cleanup checks passed\n'


### PR DESCRIPTION
## Summary
- remove Spotlight-owned command wrappers and symlinks after signed public uninstall
- remove the marker-delimited Spotlight shell block without touching user configuration
- preserve foreign files and support non-mutating dry runs
- mark newly generated wrappers as installer-managed

## Verification
- python3 tests/configurator-server-check.py
- bash tests/smoke.sh (63/63)
- bash tests/eval.sh (46/46)
- bash tests/install-spotlight-check.sh
- bash tests/install-spotlight-smoke.sh
- git diff --check