### PR TITLE
Pin public installer to Spotlight v2.1.5

### DIFF
--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -316,7 +316,7 @@ if [ -n "$SPOTLIGHT_MODEL_REPO" ]; then
 fi
 
 if [ "$PUBLIC_BUNDLE_PHASE" = "0" ] && [ "$DRY_RUN" = "0" ]; then
-  PUBLIC_RELEASE_BASE="https://github.com/buriedsignals/spotlight/releases/download/v2.1.2"
+  PUBLIC_RELEASE_BASE="https://github.com/buriedsignals/spotlight/releases/download/v2.1.5"
   PUBLIC_BOOTSTRAP_SHA256="ebe0a8b707f4b891e2b9c87fe6b65da5e31f6a4140361faf0d99400c4f9a47a7"
   command -v curl >/dev/null 2>&1 || { echo "Spotlight installer: curl is required" >&2; exit 1; }
   command -v openssl >/dev/null 2>&1 || { echo "Spotlight installer: OpenSSL is required" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- pin the hosted public installer bootstrap to the signed Spotlight v2.1.5 release
- make fresh web installs start directly on applicator v3 and the ownership-aware uninstall path

## Verification
- `bash -n install-spotlight.sh`
- `bash tests/install-spotlight-check.sh`
- `bash tests/install-spotlight-smoke.sh`
- `bash tests/install-spotlight-audit-check.sh`
- `python3 tests/dependency-pins-check.py`