### PR TITLE
docs(osint): add privacy-first metadata viewer

### DIFF
--- a/skills/osint/references/tools-by-category.md
+++ b/skills/osint/references/tools-by-category.md
@@ -1,6 +1,6 @@
 # OSINT Tools by Category
 
-150 tools curated by [OSINT Navigator](https://navigator.indicator.media).
+151 tools curated by [OSINT Navigator](https://navigator.indicator.media).
 
 Last updated: 2026-02-26
 
@@ -222,6 +222,11 @@ Maltego is an open source intelligence (OSINT) and graphical link analysis tool 
 Metadata2Go is an online tool that allows OSINT investigators to view, extract, and remove hidden metadata from various file types including images, documents, and videos.
 **Use when:** You need to extract, view, or remove metadata from a file like an image, document, or video.
 **vs. alternatives:** Metadata2Go is a web-based tool specifically designed for metadata extraction and editing, unlike general file viewers.
+
+### [Metadata Remover](https://metadataremover.ai/metadata-viewer) — metadataremover.ai [Free]
+Metadata Remover is a browser-local viewer for inspecting image metadata without uploading files to a server.
+**Use when:** You need a privacy-preserving first pass on image metadata before sharing or investigating a file.
+**vs. alternatives:** It keeps the file in the browser, but metadata should remain an investigative lead and be corroborated with another method before being treated as evidence.
 
 ### Namechk — namechk.com [Free]
 Namechk.com helps OSINT investigators and users check the availability of usernames and domain names across multiple platforms and domains within seconds.


### PR DESCRIPTION
## Summary

Adds a browser-local metadata viewer to the OSINT tools catalog for investigators who do not want to upload source images to a server. The entry also cautions that metadata should be corroborated before it is treated as evidence.

I maintain MetadataRemover.ai.

## Type of change

- [x] Docs only

## What changed

- Added Metadata Remover beside the existing Metadata2Go entry in `skills/osint/references/tools-by-category.md`.
- Documented the privacy-oriented use case and evidence limitation.
- Updated the catalog count from 150 to 151.

## Testing

- [x] Manually reviewed the rendered Markdown and destination URL.
- [ ] `bash tests/smoke.sh`
- [ ] `bash tests/eval.sh`

The full repository test suites were not run because this contribution was prepared through GitHub's web editor.