### PR TITLE
Fix public installer empty-array abort

### DIFF
--- a/install-spotlight.sh
+++ b/install-spotlight.sh
@@ -315,8 +315,8 @@ if [ -n "$SPOTLIGHT_MODEL_REPO" ]; then
 fi
 
 if [ "$PUBLIC_BUNDLE_PHASE" = "0" ] && [ "$DRY_RUN" = "0" ]; then
-  PUBLIC_RELEASE_BASE="https://github.com/buriedsignals/spotlight/releases/download/v2.1.7"
-  PUBLIC_BOOTSTRAP_SHA256="ebe0a8b707f4b891e2b9c87fe6b65da5e31f6a4140361faf0d99400c4f9a47a7"
+  PUBLIC_RELEASE_BASE="https://github.com/buriedsignals/spotlight/releases/download/v2.1.9"
+  PUBLIC_BOOTSTRAP_SHA256="cfc35920ac7ad8d5615c7db12285103d69666b39d4ef863f691c62a4d89fc0f8"
   command -v curl >/dev/null 2>&1 || { echo "Spotlight installer: curl is required" >&2; exit 1; }
   command -v openssl >/dev/null 2>&1 || { echo "Spotlight installer: OpenSSL is required" >&2; exit 1; }
   PUBLIC_BOOTSTRAP_TMP="$(mktemp "${TMPDIR:-/tmp}/spotlight-public-bootstrap.XXXXXX")"


### PR DESCRIPTION
Fixes the public bootstrap failure under Bash set -u when optional CHOICES_ARGS/ACTION_ARGS arrays are empty. Uses nounset-safe array expansion and updates the pinned public bootstrap release/hash. Focused installer checks pass.